### PR TITLE
✨ DevTalks 2026: F key toggles fullscreen on the deck host

### DIFF
--- a/static/presentations/2026-devtalks-romania/index.html
+++ b/static/presentations/2026-devtalks-romania/index.html
@@ -6172,6 +6172,14 @@ deck-stage section.light {
         this._go(this._slides.length - 1, 'keyboard');
       } else if (key === 'r' || key === 'R') {
         this._go(0, 'keyboard');
+      } else if (key === 'f' || key === 'F') {
+        // Plain 'f' as the single cross-platform toggle. Not F11: Chromium
+        // intercepts F11 at the browser level (browser-chrome fullscreen, a
+        // different surface from the Fullscreen API) before the page sees
+        // it, and macOS doesn't wire F11 to fullscreen at all — binding it
+        // here would be dead code with a misleading promise. Escape exits
+        // via the browser default — no code needed.
+        this._toggleFullscreen();
       } else if (/^[0-9]$/.test(key)) {
         // 1..9 jump to that slide; 0 jumps to 10.
         const n = key === '0' ? 9 : parseInt(key, 10) - 1;
@@ -6195,6 +6203,23 @@ deck-stage section.light {
       }
       this._index = clamped;
       this._applyIndex({ showOverlay: true, broadcast: true, reason });
+    }
+
+    _toggleFullscreen() {
+      // Request on the host element (this), not documentElement: the host is
+      // already position:fixed; inset:0, so the rail and overlay come along
+      // for the ride. The === this check (not just truthy) keeps the toggle
+      // host-scoped: if some other element (a future image lightbox, an
+      // embedded video) is the fullscreen owner, 'f' won't yank it out — it
+      // promotes the deck instead (the Fullscreen API supports transitioning
+      // between elements without an explicit exit). catch() swallows the
+      // user-gesture-required / not-allowed rejection paths so a denied call
+      // doesn't surface as an unhandled promise rejection.
+      if (document.fullscreenElement === this) {
+        document.exitFullscreen().catch(() => {});
+      } else {
+        this.requestFullscreen({ navigationUI: 'hide' }).catch(() => {});
+      }
     }
 
     /** Step forward/back skipping any slide marked data-deck-skip. Falls


### PR DESCRIPTION
Closes https://github.com/manusa/com.marcnuri.automated-tasks/issues/1805.

## Summary

- `<deck-stage>` now binds **`f`** / **`F`** to a Fullscreen API toggle on the host element.
- Calls `requestFullscreen({ navigationUI: 'hide' })` on enter and `document.exitFullscreen()` on exit. Escape still exits via the browser default — no code needed.
- The exit branch is gated to `document.fullscreenElement === this`, so a future child element (image lightbox, embedded video, …) going fullscreen can't be yanked out of fullscreen by an `f` press inside the deck.
- **F11 is intentionally not bound.** Chromium claims F11 at the browser level on Windows/Linux before the page sees it (browser-chrome fullscreen, a different surface from the Fullscreen API). macOS doesn't wire F11 to fullscreen at all. Binding it here would be dead code with a misleading promise.

## Why `{ navigationUI: 'hide' }`

Matches the option used by the older Gatsby `slide-controls` (`src/components/slide-controls/slide-controls.jsx:36`), originally added to deal with macOS Chrome's fullscreen quirks.

## Test plan

- [ ] Open the deck, press \`f\` — deck enters fullscreen
- [ ] Press \`Escape\` — deck exits fullscreen (browser default)
- [ ] Press \`f\` again, then \`F\` — deck exits fullscreen via the toggle
- [ ] Type \`f\` in any future input/textarea on the page — no toggle (editable-target guard preserved from the existing \`_onKey\`)
- [ ] \`Ctrl+f\` / \`Cmd+f\` — browser's "Find on page" still opens (modifier guard preserved)
- [ ] \`ArrowRight\` / \`ArrowLeft\` / \`Home\` / \`End\` / \`0-9\` / \`r\` — still navigate as before
- [ ] Snapshot diff vs pre-change baseline — no visual regression