### PR TITLE
🐛 DevTalks 2026: fix thumbnail rendering of light + image-slot slides

### DIFF
--- a/static/presentations/2026-devtalks-romania/index.html
+++ b/static/presentations/2026-devtalks-romania/index.html
@@ -6179,7 +6179,22 @@ deck-stage section.light {
         .replace(/:root((?:\[[^\]]*\]|[.#][-\w]+|:[-\w]+(?:\([^)]*\))?)+)/g, ':host($1)')
         .replace(/:root\b/g, ':host')
         .replace(/(^|[\s,>~+(}])html((?:\[[^\]]*\]|[.#][-\w]+|:[-\w]+(?:\([^)]*\))?)+)(?![-\w])/g, '$1:host($2)')
-        .replace(/(^|[\s,>~+(}])html(?![-\w])/g, '$1:host');
+        .replace(/(^|[\s,>~+(}])html(?![-\w])/g, '$1:host')
+        // The cloned slide lives in a thumb shadow root, so it has no
+        // <deck-stage> ancestor — author rules like `deck-stage section`
+        // or `deck-stage section.light` (which scope slide background +
+        // theme to slides inside the live deck) would never match, leaving
+        // light slides transparent over the rewritten html→:host black.
+        // Drop the deck-stage prefix when it's used as a CSS type selector
+        // so the descendant rule reaches the cloned section.
+        .replace(/(^|[\s,>~+(}])deck-stage(?![-\w])/g, '$1')
+        // Same idea for <image-slot>: `_materialize` swaps each cloned
+        // slot for a <div> (its <img> lives in shadow DOM, lost to
+        // cloneNode), so author rules that pin `image-slot.scene-slot`
+        // sizing or `image-slot[data-filled]` siblings need to reach the
+        // replacement element. Drop the `image-slot` tag prefix so the
+        // class/attribute compounds still match the <div>.
+        .replace(/(^|[\s,>~+(}])image-slot(?![-\w])/g, '$1');
       // Every custom property the author references. _syncThumbHostAttrs
       // mirrors each one's *computed* value at <deck-stage> onto the
       // thumb host so the live value wins over the :host default above
@@ -6996,6 +7011,38 @@ deck-stage section.light {
         img.style.cssText = el.style.cssText + ';object-fit:cover;width:100%;height:100%;';
         img.className = el.className;
         el.replaceWith(img);
+      });
+      // <image-slot> renders its <img> inside its own shadow DOM; cloneNode
+      // does not traverse shadow roots, so the cloned slot is empty and the
+      // generic neuter pass below would otherwise discard it as a dashed
+      // placeholder. Stand up a plain <div><img></div> in its place, copying
+      // the slot's attributes (incl. class + data-filled) so the author
+      // sizing rules — `.proj-card .picon { width:72px; height:72px }`,
+      // `.s-about2 .photo-slot { aspect-ratio:4/5 }`, and the
+      // `.scene-slot { width:100%; height:100% }` that the
+      // image-slot → tag-strip rewrite in _snapshotAuthorCss makes reachable
+      // — keep driving the layout. Sizing is therefore handed back to CSS;
+      // the inner <img> just fills its parent with the slot's fit/position.
+      clone.querySelectorAll('image-slot').forEach((el) => {
+        const div = document.createElement('div');
+        for (const a of el.attributes) {
+          if (a.name === 'src') continue;
+          div.setAttribute(a.name, a.value);
+        }
+        const inlineStyle = el.getAttribute('style');
+        if (inlineStyle) div.setAttribute('style', inlineStyle);
+        const src = el.getAttribute('src');
+        if (src) {
+          const img = document.createElement('img');
+          img.src = src;
+          img.alt = '';
+          const fit = el.getAttribute('fit') || 'cover';
+          const pos = el.getAttribute('position') || '50% 50%';
+          img.style.cssText = 'display:block;width:100%;height:100%;object-fit:' +
+            fit + ';object-position:' + pos + ';';
+          div.appendChild(img);
+        }
+        el.replaceWith(div);
       });
       // Images: defer decode and let the browser pick the smallest
       // srcset candidate for the ~140px thumb. Same-URL clones reuse the


### PR DESCRIPTION
Closes manusa/com.marcnuri.automated-tasks#1807.

## What was wrong

In the deck-stage thumbnail rail of the DevTalks Romania 2026 deck, most light-themed slides rendered as plain black tiles, and the two `.s-amplifier` slides lost their hero scene image:

- **Light slides** (3, 4, 5, 13, 14, 15, 17, 18, 19) — the author rule `deck-stage section.light { background: var(--bg) }` could not match the cloned `<section>` inside each thumb's shadow root (no `<deck-stage>` ancestor), so the section was transparent over the host's rewritten `html → :host` black background.
- **Amp-scene slides** (11, 12) — `<image-slot>` renders its `<img>` inside its own shadow DOM. `cloneNode(true)` does not traverse shadow roots, so the cloned slot was empty; the generic "neuter custom elements" pass then replaced it with a dashed placeholder, discarding the image.

## Fix

Two surgical changes in `static/presentations/2026-devtalks-romania/index.html`, both in thumb-only code paths:

1. **`_snapshotAuthorCss`** — strip `deck-stage` and `image-slot` when used as CSS type selectors, so the class/attribute compounds (`section.light`, `.scene-slot`, `[data-filled]`) reach the cloned DOM. Mirrors the existing `:root → :host` / `html → :host` rewrites.
2. **`_materialize`** — before the generic custom-element neuter, rehydrate each cloned `<image-slot>` into a `<div><img></div>` that copies the slot's attributes and reads `src`/`fit`/`position` from the live element. Sizing stays with the class rules so portraits and project logos render at the right scale.

## Test plan

- Light slides now show the cream `rgb(244, 241, 232)` background in the rail (was `rgba(0,0,0,0)`).
- Amp-scene slides 11/12 display the hero photos in the rail.
- Slides 3/4 show the portrait + project logos at the correct sizes.
- `npm run snapshot:diff -- … devtalks-2026` reports 21/22 slides identical to the pre-edit baseline; the remaining 0.014% diff on slide 22 is the blinking terminal cursor on the `s-code` slide (pre-existing animation noise, unrelated).