### PR TITLE
🐛 DevTalks 2026: hide thumbnail rail in fullscreen

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -168,5 +168,6 @@ The NPM workflow runs `replaceDependencies.sh` before publish — it rewrites `d
 ## Repo Conventions
 
 - Commit messages use **gitmoji** (`✨` feature, `🐛` fix, `♻️` refactor, `👷` CI, etc.) plus a short imperative subject (see `git log`).
+- **Cross-repo issue references** — tracker issues for this repo live in `manusa/com.marcnuri.automated-tasks`, not in `manusa/presentations`. A bare `Fixes #1234` in a commit or PR body resolves against the *current* repo and silently does nothing for tracker issues. Always use the full `owner/repo#N` coordinate: `Fixes manusa/com.marcnuri.automated-tasks#1234`. Without it the tracker issue stays open after merge.
 - Per-deck SCSS variables and mixins live under `src/components/<deck-slug>/styles/` (Gatsby decks only).
 - Custom-domain config: `static/CNAME` — do not move.

--- a/static/presentations/2026-devtalks-romania/index.html
+++ b/static/presentations/2026-devtalks-romania/index.html
@@ -2957,6 +2957,13 @@
       this._hideTimer = null;
       this._mouseIdleTimer = null;
       this._menuIndex = -1;
+      // Two independent presenting sources OR-merged into _presenting by
+      // _syncPresenting: an Omelette host posting __omelette_presenting,
+      // and the user putting the deck host in standalone fullscreen. Track
+      // them separately so neither one can clobber the other on toggle.
+      this._omelettePresenting = false;
+      this._fullscreenPresenting = false;
+      this._presenting = false;
 
       this._onKey = this._onKey.bind(this);
       this._onResize = this._onResize.bind(this);
@@ -2965,6 +2972,7 @@
       this._onTapBack = this._onTapBack.bind(this);
       this._onTapForward = this._onTapForward.bind(this);
       this._onMessage = this._onMessage.bind(this);
+      this._onFullscreenChange = this._onFullscreenChange.bind(this);
       // Capture-phase close so a click anywhere dismisses the menu, but
       // ignore clicks that land inside the menu itself — otherwise the
       // capture handler runs before the menu's own (bubble) handler and
@@ -2995,6 +3003,8 @@
       window.addEventListener('mousemove', this._onMouseMove, { passive: true });
       window.addEventListener('message', this._onMessage);
       window.addEventListener('click', this._onDocClick, true);
+      document.addEventListener('fullscreenchange', this._onFullscreenChange);
+      document.addEventListener('webkitfullscreenchange', this._onFullscreenChange);
       // Initial collection + layout happens via slotchange, which fires on mount.
       this._enableRail();
       // Hold the stage hidden until webfonts are ready so the first visible
@@ -3197,6 +3207,8 @@
       window.removeEventListener('mousemove', this._onMouseMove);
       window.removeEventListener('message', this._onMessage);
       window.removeEventListener('click', this._onDocClick, true);
+      document.removeEventListener('fullscreenchange', this._onFullscreenChange);
+      document.removeEventListener('webkitfullscreenchange', this._onFullscreenChange);
       if (this._hideTimer) clearTimeout(this._hideTimer);
       if (this._mouseIdleTimer) clearTimeout(this._mouseIdleTimer);
       if (this._liveTimer) clearTimeout(this._liveTimer);
@@ -3605,16 +3617,8 @@
     _onMessage(e) {
       const d = e.data;
       if (d && typeof d.__omelette_presenting === 'boolean') {
-        this._presenting = d.__omelette_presenting;
-        if (this._presenting && this._overlay) {
-          this._overlay.removeAttribute('data-visible');
-          if (this._hideTimer) clearTimeout(this._hideTimer);
-        }
-        this._syncRailHidden();
-        this._closeMenu();
-        this._closeConfirm();
-        this._fit();
-        this._scaleThumbs();
+        this._omelettePresenting = d.__omelette_presenting;
+        this._syncPresenting();
       }
       // Host's Preview segment (ViewerMode='none'): the rail's drag-reorder /
       // right-click skip-delete affordances are editing chrome, so hide it
@@ -3649,6 +3653,35 @@
         this._railAnimTimer = setTimeout(() => this.removeAttribute('data-rail-anim'), 220);
       }
       if (d && d.type === '__omelette_rail_enabled') this._enableRail();
+    }
+
+    _onFullscreenChange() {
+      // Scope is host-only so a fullscreen lightbox or video elsewhere
+      // doesn't collapse the rail. webkitFullscreenElement covers Safari
+      // builds older than 16.4; in modern Safari both reads return the
+      // same node.
+      const fsEl = document.fullscreenElement || document.webkitFullscreenElement;
+      this._fullscreenPresenting = fsEl === this;
+      this._syncPresenting();
+    }
+
+    /** OR-merge the two presenting sources into _presenting, then apply
+     *  the chrome-free view (hide rail, suppress overlay, refit canvas).
+     *  Early-return on no-op so a same-state postMessage or duplicate
+     *  fullscreenchange doesn't thrash _fit / _scaleThumbs. */
+    _syncPresenting() {
+      const presenting = this._omelettePresenting || this._fullscreenPresenting;
+      if (presenting === this._presenting) return;
+      this._presenting = presenting;
+      if (presenting && this._overlay) {
+        this._overlay.removeAttribute('data-visible');
+        if (this._hideTimer) clearTimeout(this._hideTimer);
+      }
+      this._syncRailHidden();
+      this._closeMenu();
+      this._closeConfirm();
+      this._fit();
+      this._scaleThumbs();
     }
 
     _syncRailHidden() {
@@ -3752,10 +3785,16 @@
       // between elements without an explicit exit). catch() swallows the
       // user-gesture-required / not-allowed rejection paths so a denied call
       // doesn't surface as an unhandled promise rejection.
-      if (document.fullscreenElement === this) {
-        document.exitFullscreen().catch(() => {});
+      // Promise.resolve wrapping handles old Safari's webkitRequestFullscreen,
+      // which is sync (returns undefined) — modern unprefixed APIs return a
+      // promise.
+      const fsEl = document.fullscreenElement || document.webkitFullscreenElement;
+      if (fsEl === this) {
+        const exit = document.exitFullscreen || document.webkitExitFullscreen;
+        if (exit) Promise.resolve(exit.call(document)).catch(() => {});
       } else {
-        this.requestFullscreen({ navigationUI: 'hide' }).catch(() => {});
+        const req = this.requestFullscreen || this.webkitRequestFullscreen;
+        if (req) Promise.resolve(req.call(this, { navigationUI: 'hide' })).catch(() => {});
       }
     }
 


### PR DESCRIPTION
## Summary

- Hide the DevTalks Romania deck's thumbnail rail when the host element enters fullscreen (F key or any `requestFullscreen` on `<deck-stage>`). Previously the rail stayed visible because the hard-hide path was only wired to the Omelette host's `__omelette_presenting` postMessage.
- Track Omelette presenting and standalone fullscreen as two independent flags (`_omelettePresenting`, `_fullscreenPresenting`) OR-merged into `_presenting` by a new `_syncPresenting` helper. Neither source can clobber the other on toggle.
- Cross-browser: pair `webkitfullscreenchange` with the standard event, and let `_toggleFullscreen` fall back to `webkitRequestFullscreen` / `webkitExitFullscreen` with a `Promise.resolve` wrapper that tolerates old Safari's sync return.
- AGENTS.md: codify the cross-repo `Fixes owner/repo#N` rule — tracker issues live in `manusa/com.marcnuri.automated-tasks`, so bare `Fixes #N` references silently no-op.

Fixes manusa/com.marcnuri.automated-tasks#1806.

## Test plan

- [x] In-browser test (Chrome): rail collapses on `fullscreenchange` with `document.fullscreenElement === <deck-stage>`, restores on exit. Canvas refits flush-left (`stage.style.left` 188px → 0px → 188px).
- [x] State-fight matrix: omelette=true → FS=true → omelette=false (FS still true) keeps `_presenting=true` and the rail hidden. Exiting FS restores everything.
- [x] Webkit-only path: `webkitfullscreenchange` with `document.webkitFullscreenElement` toggles `_fullscreenPresenting` and the rail.
- [x] Listener cleanup: `disconnectedCallback` now removes both `fullscreenchange` and `webkitfullscreenchange`, verified via spy.
- [x] `snapshot:diff` regression: all 22 slides identical to the pre-edit baseline (non-fullscreen browsing path unchanged).