### PR TITLE
📝 deck-kit: enumerate Supported API surface + freeze contract

### DIFF
--- a/static/deck-kit/README.md
+++ b/static/deck-kit/README.md
@@ -15,7 +15,11 @@ build step. Loaded directly via `<script src=…>`.
 ## What does **not** live here
 
 - **Per-deck content, CSS, assets.** Those stay under `static/presentations/<slug>/`.
-- **Deck-specific glue scripts** (e.g. the step-reveal handler keyed off `data-step-max`, logo / scene image registries). These remain inline in each deck's `index.html` until 2+ decks share the same contract (see rule #4 below).
+- **Deck-specific glue scripts** (e.g. logo / scene image registries; the
+  `.s-amplifier` → `data-step-max` auto-stamp loop in the DevTalks deck).
+  These remain inline in each deck's `index.html` until 2+ decks share the
+  same contract (see rule #4 below). The step-reveal mechanism itself is
+  first-class (see `data-step-max` below).
 - **A build step.** The files here are plain ES2018 — no transpile, no bundle, no minify.
 
 ## Stability promise (the five rules)
@@ -23,14 +27,14 @@ build step. Loaded directly via `<script src=…>`.
 These are non-negotiable. The components currently power one shipped (or about-to-ship) deck; as more decks adopt them, regressions break talks that have already been given.
 
 1. **Attribute-based opt-in only, never opt-out.** New features gate behind new attributes; unspecified attribute = legacy behavior. Examples: `<deck-stage noscale>` and `<deck-stage no-rail>` add behavior; nothing is opt-out.
-2. **Events out, never callbacks/imports in.** Core dispatches `CustomEvent`s; deck code listens. Core never knows about specific decks. Example: the `slidechange` event powers the deck's step-reveal script today.
+2. **Events out, never callbacks/imports in.** Core dispatches `CustomEvent`s; deck code listens. Core never knows about specific decks. Example: deck slides can listen to `slidechange` to drive their own enter/leave animations.
 3. **Append-only attributes, events, and `event.detail` shapes.** Once shipped, frozen. The `contract.spec.js` test (under `tests/deck-kit/`) enforces this mechanically — renaming or removing a name makes it fail loudly.
 4. **Composition over feature creep.** Deck-specific behavior stays in the deck until 2+ decks need the same thing.
 5. **Breaking change = new filename** (`deck-stage-v2.js`). Old decks keep pointing at the old file.
 
 ## Wiring a static deck
 
-Drop both scripts at the bottom of `<body>` with `defer`. Inline registries (logos, scene images) and `data-step-max` step-reveal glue stay inline in the deck for now and run after upgrade because they wait on `DOMContentLoaded`:
+Drop both scripts at the bottom of `<body>` with `defer`. Inline per-deck glue (logo / scene-image registries, slide-class auto-stamping) stays inline in the deck and runs after upgrade because it waits on `DOMContentLoaded`:
 
 ```html
 <!doctype html>
@@ -53,13 +57,84 @@ Drop both scripts at the bottom of `<body>` with `defer`. Inline registries (log
 </html>
 ```
 
-Attributes the components understand:
+## Supported API surface
 
-- `<deck-stage>` observed: `width`, `height`, `noscale`, `no-rail`.
-- `<deck-stage>` slide attributes read on `<section>`s: `data-label`, `data-deck-skip`.
-- `<deck-stage>` events: `slidechange` (`{index, previousIndex, total, slide, previousSlide, reason}`) and `deckchange` (`{action, from, to?, slide}`). Both bubble and cross the shadow boundary (`composed: true`).
-- `<deck-stage>` API: `index`, `length`, `goTo(i)`, `next()`, `prev()`, `reset()`.
-- `<image-slot>` observed: `shape`, `radius`, `mask`, `fit`, `position`, `placeholder`, `src`, `id`.
+The complete, frozen contract per rule #3. Every name below is asserted by
+`tests/deck-kit/contract.spec.js` — renaming or removing any of them must
+flow through rule #5 (new filename). Anything **not** listed is an
+implementation detail and may change without a filename bump.
+
+### `<deck-stage>` attributes
+
+- `width`, `height` — design viewport (default 1920×1080).
+- `noscale` — skip auto-scaling fit-to-viewport; render at 1:1.
+- `no-rail` — hide the thumbnail rail.
+
+### `<section>` attributes (read by deck-stage)
+
+- `data-label` — text shown in the rail; required for legible nav.
+- `data-deck-skip` — exclude this section from rail nav + keyboard advance.
+- `data-step-max="N"` — N+1 reveal states (`data-step="0".."N"`). Advance keys
+  (ArrowRight / PageDown / Space / Enter) bump `data-step` until it reaches
+  `N`, then resume slide advance; retreat keys (ArrowLeft / PageUp) mirror.
+- `data-step` — runtime state, managed by deck-stage. Snaps to `0` whenever
+  the slide is entered or left. Do not set manually past markup-default `0`.
+
+### Keyboard bindings
+
+- `ArrowRight` / `PageDown` / `Space` / `Enter` — advance step (when
+  `data-step-max` in range) or slide.
+- `ArrowLeft` / `PageUp` — retreat step or slide.
+- `Home` / `End` — first / last slide.
+- `0`..`9` — jump to first 10 slides (`1`→1, …, `9`→9, `0`→10).
+- `R` — reset to slide 1, step 0.
+- `F` — toggle fullscreen.
+
+### URL hash
+
+- `#<integer>` — on load, deep-link to that section index (1-based).
+  `#3` lands on the third section. Updated on every nav so an in-iframe
+  reload lands on the current slide.
+
+### `<image-slot>` attributes
+
+- `id` — persistence key; required for a dropped image to survive reload.
+- `src` — initial / fallback image URL. Set inline (preferred) or via JS.
+  A user drop overrides it; clearing the drop reveals `src` again.
+- `shape` — `'rect' | 'rounded' | 'circle' | 'pill'` (default `'rounded'`).
+- `radius` — corner radius in px for `shape="rounded"` (default 12).
+- `mask` — any CSS `clip-path` value. Overrides `shape`.
+- `fit` — `'cover' | 'contain' | 'fill'` (default `'cover'`).
+- `position` — `object-position` value for `fit=contain|fill` (default `'50% 50%'`).
+- `placeholder` — empty-state caption (default `'Drop an image'`).
+
+### `<image-slot>` CSS hooks
+
+- `[data-filled]` — set on the host once `src` (or a user drop) resolves.
+  Use `image-slot[data-filled] { … }` for fill-only styling.
+- `::part(frame)` / `::part(image)` / `::part(empty)` / `::part(ring)` —
+  expose the inner crop frame, the inner `<img>`, the empty-state container,
+  and the dashed drop-target ring for external styling.
+
+### Events
+
+Both events bubble and cross the shadow boundary (`composed: true`), so
+listeners attach either on the `<deck-stage>` element or on `document`.
+
+- `slidechange` — fires on every slide transition, including the initial
+  mount. `event.detail = { index, previousIndex, total, slide, previousSlide, reason }`
+  where `reason ∈ { 'init', 'keyboard', 'click', 'tap', 'api', 'mutation' }`.
+- `deckchange` — fires on rail-driven mutations (move / skip / unskip / delete).
+  `event.detail = { action, from, to?, slide }` where
+  `action ∈ { 'delete', 'skip', 'unskip', 'move' }` (`to` only present for `'move'`).
+
+### `<deck-stage>` JavaScript API
+
+- `index` — current 0-based slide index (read-only).
+- `length` — slide count (read-only).
+- `goTo(i)` — navigate to a 0-based index.
+- `next()` / `prev()` — advance / retreat one slide.
+- `reset()` — back to slide 0.
 
 ## Running the test suite
 

--- a/static/deck-kit/deck-stage.js
+++ b/static/deck-kit/deck-stage.js
@@ -1124,6 +1124,14 @@
         if (i === curr) s.setAttribute('data-deck-active', '');
         else s.removeAttribute('data-deck-active');
       });
+      // Step-reveal reset: any stepped slide we either entered or just
+      // left snaps data-step back to 0 so a future re-entry starts from
+      // the first reveal state. (data-step-max itself is author-set and
+      // never touched.)
+      const prevSlide = prev >= 0 ? this._slides[prev] : null;
+      const currSlide = this._slides[curr];
+      if (prevSlide && prevSlide.hasAttribute('data-step-max')) prevSlide.setAttribute('data-step', '0');
+      if (currSlide && currSlide.hasAttribute('data-step-max')) currSlide.setAttribute('data-step', '0');
       if (this._countEl) this._countEl.textContent = String(curr + 1);
       // Follow-scroll on every navigation (init deep-link, keyboard, click,
       // tap, external goTo) — the only time we *don't* want the rail to
@@ -1313,9 +1321,15 @@
     }
 
     _onKey(e) {
-      // Ignore when the user is typing.
+      // Ignore when the user is interacting with a form field or focused
+      // button. BUTTON matters because Enter (and Space) advance both via
+      // the button's native click activation AND via this nav handler —
+      // suppressing here lets the button keep its native semantics.
+      // Shadow-DOM overlay buttons retarget to the deck-stage host on
+      // window-level events, so the guard only kicks in for light-DOM
+      // buttons authored inside slides.
       const t = e.target;
-      if (t && (t.isContentEditable || /^(INPUT|TEXTAREA|SELECT)$/.test(t.tagName))) return;
+      if (t && (t.isContentEditable || /^(INPUT|TEXTAREA|SELECT|BUTTON)$/.test(t.tagName))) return;
       // Confirm dialog swallows nav keys while open; Escape cancels. Enter
       // is left to the focused button's native activation so Tab→Cancel
       // →Enter activates Cancel, not the window-level confirm path.
@@ -1333,15 +1347,48 @@
       const key = e.key;
       let handled = true;
 
-      if (key === 'ArrowRight' || key === 'PageDown' || key === ' ' || key === 'Spacebar') {
+      // Step-reveal: a slide carrying data-step-max="N" expands into N+1
+      // sub-states (0..N), navigable inline. Advance keys bump data-step
+      // until step == max, then fall through to the next slide; retreat
+      // mirrors. data-step itself is owned by deck-stage (reset in
+      // _applyIndex) so re-entering a stepped slide replays cleanly.
+      const isAdvance = (key === 'ArrowRight' || key === 'PageDown' || key === ' ' || key === 'Spacebar' || key === 'Enter');
+      const isRetreat = (key === 'ArrowLeft'  || key === 'PageUp');
+      if (isAdvance || isRetreat) {
+        const slide = this._slides[this._index];
+        const max = slide && parseInt(slide.getAttribute('data-step-max') || '0', 10);
+        if (slide && max > 0) {
+          const cur = parseInt(slide.getAttribute('data-step') || '0', 10);
+          if (isAdvance && cur < max) {
+            slide.setAttribute('data-step', String(cur + 1));
+            e.preventDefault();
+            this._flashOverlay();
+            return;
+          }
+          if (isRetreat && cur > 0) {
+            slide.setAttribute('data-step', String(cur - 1));
+            e.preventDefault();
+            this._flashOverlay();
+            return;
+          }
+        }
+      }
+
+      if (isAdvance) {
         this._advance(1, 'keyboard');
-      } else if (key === 'ArrowLeft' || key === 'PageUp') {
+      } else if (isRetreat) {
         this._advance(-1, 'keyboard');
       } else if (key === 'Home') {
         this._go(0, 'keyboard');
       } else if (key === 'End') {
         this._go(this._slides.length - 1, 'keyboard');
       } else if (key === 'r' || key === 'R') {
+        // _go short-circuits when already on slide 0, which would otherwise
+        // skip _applyIndex's step-reset and leave data-step stuck at its
+        // current value for an opening stepped slide. Reset here before
+        // dispatching so R always lands on "slide 1, step 0" per README.
+        const cur = this._slides[this._index];
+        if (cur && cur.hasAttribute('data-step-max')) cur.setAttribute('data-step', '0');
         this._go(0, 'keyboard');
       } else if (key === 'f' || key === 'F') {
         // Plain 'f' as the single cross-platform toggle. Not F11: Chromium

--- a/static/presentations/2026-devtalks-romania/index.html
+++ b/static/presentations/2026-devtalks-romania/index.html
@@ -3010,97 +3010,12 @@ tasks.<span class="t-fn">register</span>(<span class="t-str">"quickBuild"</span>
 </script>
 
 <script>
-/* ============================================================
-   Manual step reveal for any slide that opts in via data-step-max.
-
-   Examples:
-     .s-amplifier — three states (image-only → cards → takeaway)
-     .s-about2-flip — two states (day_job face → after_hours face)
-
-   We intercept advance/back keys + clicks in capture phase. While the
-   active slide publishes data-step-max and the step is in range, we
-   bump the step ourselves and SWALLOW the event so deck-stage doesn't
-   navigate. Only once a slide is fully revealed (or fully unwound) does
-   navigation pass through.
-
-   The .s-amplifier slides authored before this generalisation didn't
-   carry data-step-max in markup, so we still stamp them here.
-   ============================================================ */
-(function() {
-  // After init, every stepped slide carries data-step-max — amplifier slides
-  // get it stamped below, the about slide ships with it in markup. That makes
-  // [data-step-max] the canonical "is stepped" selector. Don't build a list
-  // selector like '[data-step-max], .s-amplifier' and then concat
-  // '[data-deck-active]' to it — the comma makes the trailing attribute
-  // selector bind to only the LAST item, so '[data-step-max]' starts matching
-  // inactive stepped slides and silently swallows keypresses on other slides.
-  const AMPLIFIER_MAX_STEP = 1;
-  const ADVANCE_KEYS = new Set(['ArrowRight', 'PageDown', 'Space', ' ', 'Enter']);
-  const BACK_KEYS    = new Set(['ArrowLeft',  'PageUp']);
-
-  function maxStep(slide) {
-    return parseInt(slide.getAttribute('data-step-max') || '0', 10);
-  }
-
-  // Stamp data-step-max on amplifier slides (they predate the contract).
-  document.querySelectorAll('.s-amplifier').forEach((s) => {
-    if (!s.hasAttribute('data-step-max')) {
-      s.setAttribute('data-step-max', String(AMPLIFIER_MAX_STEP));
-    }
-  });
-  // Initialise data-step on every stepped slide once attributes are stamped.
-  document.querySelectorAll('[data-step-max]').forEach((s) => {
-    if (!s.hasAttribute('data-step')) s.setAttribute('data-step', '0');
-  });
-
-  // Reset step on slide enter so re-entering replays cleanly.
-  document.addEventListener('slidechange', (e) => {
-    const slide = e.detail && e.detail.slide;
-    if (slide && slide.matches && slide.matches('[data-step-max]')) {
-      slide.setAttribute('data-step', '0');
-    }
-    const prev = e.detail && e.detail.previousSlide;
-    if (prev && prev.matches && prev.matches('[data-step-max]')) {
-      prev.setAttribute('data-step', '0');
-    }
-  });
-
-  function activeStepped() {
-    return document.querySelector('[data-step-max][data-deck-active]');
-  }
-
-  function tryAdvance(slide) {
-    const cur = parseInt(slide.getAttribute('data-step') || '0', 10);
-    if (cur < maxStep(slide)) {
-      slide.setAttribute('data-step', String(cur + 1));
-      return true;
-    }
-    return false;
-  }
-
-  function tryRetreat(slide) {
-    const cur = parseInt(slide.getAttribute('data-step') || '0', 10);
-    if (cur > 0) {
-      slide.setAttribute('data-step', String(cur - 1));
-      return true;
-    }
-    return false;
-  }
-
-  window.addEventListener('keydown', (ev) => {
-    if (ev.defaultPrevented) return;
-    if (ev.ctrlKey || ev.metaKey || ev.altKey) return;
-    const slide = activeStepped();
-    if (!slide) return;
-
-    if (ADVANCE_KEYS.has(ev.key)) {
-      if (tryAdvance(slide)) { ev.preventDefault(); ev.stopImmediatePropagation(); }
-    } else if (BACK_KEYS.has(ev.key)) {
-      if (tryRetreat(slide)) { ev.preventDefault(); ev.stopImmediatePropagation(); }
-    }
-  }, true);
-
-})();
+// Stamp data-step-max on .s-amplifier slides (they predate the deck-kit
+// contract). Everything past this point — the step machine, the
+// slide-change reset, the keyboard intercept — lives in deck-stage.js.
+document.querySelectorAll('.s-amplifier').forEach((s) => {
+  if (!s.hasAttribute('data-step-max')) s.setAttribute('data-step-max', '1');
+});
 </script>
 
 <script>

--- a/tests/deck-kit/contract.spec.js
+++ b/tests/deck-kit/contract.spec.js
@@ -13,6 +13,10 @@ const { startServer, bootDeck } = require('./_helpers');
 
 const IMAGE_SLOT_ATTRS = ['shape', 'radius', 'mask', 'fit', 'position', 'placeholder', 'src', 'id'];
 const DECK_STAGE_ATTRS = ['width', 'height', 'noscale', 'no-rail'];
+// `<section>` data-* attributes that deck-stage reads from consumer markup.
+// data-step is runtime state managed by deck-stage; data-step-max and
+// data-deck-skip are author-set; data-label is author-set.
+const SECTION_DATA_ATTRS = ['data-label', 'data-deck-skip', 'data-step-max', 'data-step'];
 const SLIDECHANGE_DETAIL_KEYS = ['index', 'previousIndex', 'total', 'slide', 'previousSlide', 'reason'];
 const SLIDECHANGE_REASONS = ['init', 'keyboard', 'click', 'tap', 'api', 'mutation'];
 const DECKCHANGE_DETAIL_KEYS = ['action', 'from', 'to', 'slide'];
@@ -156,5 +160,315 @@ describe('deck-kit contract — append-only', () => {
       assert.ok(ok, `public API member "${name}" missing on <deck-stage>`);
     }
     await page.close();
+  });
+
+  // ── URL hash deep-link ────────────────────────────────────────────────
+  // Loading `index.html#3` must land on the third section (1-based).
+  // This is the documented contract that screenshot:deck and the
+  // host's ?slide= → location.hash bridge rely on.
+  test('hash #N deep-links to section index N-1 on load', async () => {
+    const page = await browser.newPage();
+    await bootDeck(page, server.fixture('minimal-deck.html') + '#3');
+    assert.equal(await page.evaluate(() => document.querySelector('deck-stage').index), 2);
+    await page.close();
+  });
+
+  // ── Keyboard contract ─────────────────────────────────────────────────
+  // One assertion per documented binding. Duplicates per-handler tests in
+  // deck-stage.spec.js by design — this file is the contract allowlist,
+  // so removing a binding must fail HERE first.
+  test('keyboard contract: ArrowRight / ArrowLeft / PageDown / PageUp / Space / Enter / Home / End / R / 0-9', async () => {
+    const page = await browser.newPage();
+    await bootDeck(page, server.fixture('minimal-deck.html'));
+    const stage = () => page.evaluate(() => document.querySelector('deck-stage').index);
+
+    await page.keyboard.press('ArrowRight');
+    assert.equal(await stage(), 1, 'ArrowRight');
+    await page.keyboard.press('ArrowLeft');
+    assert.equal(await stage(), 0, 'ArrowLeft');
+    await page.keyboard.press('PageDown');
+    assert.equal(await stage(), 1, 'PageDown');
+    await page.keyboard.press('PageUp');
+    assert.equal(await stage(), 0, 'PageUp');
+    await page.keyboard.press('Space');
+    assert.equal(await stage(), 1, 'Space');
+    await page.keyboard.press('Enter');
+    assert.equal(await stage(), 2, 'Enter');
+    await page.keyboard.press('Home');
+    assert.equal(await stage(), 0, 'Home');
+    await page.keyboard.press('End');
+    assert.equal(await stage(), 5, 'End');
+    await page.keyboard.press('r');
+    assert.equal(await stage(), 0, 'r resets');
+    await page.keyboard.press('3');
+    assert.equal(await stage(), 2, '3 jumps to slide index 2');
+    await page.close();
+  });
+
+  // The `0` key is documented as "jump to slide 10". On a sub-10-slide
+  // deck it must be a no-op (no clamp, no wrap). Covers the
+  // key === '0' ? 9 : ... branch in deck-stage._onKey.
+  test('keyboard: 0 maps to slide 10 — no-op when deck has <10 slides', async () => {
+    const page = await browser.newPage();
+    await bootDeck(page, server.fixture('minimal-deck.html'));
+    await page.evaluate(() => document.querySelector('deck-stage').goTo(2));
+    await page.keyboard.press('0');
+    assert.equal(await page.evaluate(() => document.querySelector('deck-stage').index), 2);
+    await page.close();
+  });
+
+  // F is documented as fullscreen-toggle. The Fullscreen API is gated in
+  // headless Chromium, so we stub _toggleFullscreen and assert the key
+  // routes there. Catches a regression that drops the F binding.
+  test('keyboard: F routes to _toggleFullscreen', async () => {
+    const page = await browser.newPage();
+    await bootDeck(page, server.fixture('minimal-deck.html'));
+    await page.evaluate(() => {
+      const stage = document.querySelector('deck-stage');
+      window.__fsCalls = 0;
+      stage._toggleFullscreen = () => { window.__fsCalls++; };
+    });
+    await page.keyboard.press('f');
+    assert.equal(await page.evaluate(() => window.__fsCalls), 1);
+    await page.close();
+  });
+
+  // ── Image-slot per-attribute wiring ───────────────────────────────────
+  // observedAttributes guarantees the names — these confirm each one
+  // actually plumbs through to the rendered shadow DOM, not just sits in
+  // the allowlist. If shape/radius/fit/etc. ever silently stops applying,
+  // the surface is "documented but broken" — fail loudly here.
+  test('image-slot per-attribute wiring: shape, radius, mask, fit, position, placeholder, src', async () => {
+    const page = await browser.newPage();
+    await page.goto(server.fixture('image-slot.html'));
+    await page.waitForFunction(() => !!customElements.get('image-slot'));
+    const wired = await page.evaluate(() => {
+      const get = (id, fn) => {
+        const el = document.getElementById(id);
+        const frame = el.shadowRoot.querySelector('.frame');
+        const img = el.shadowRoot.querySelector('img');
+        return fn({ el, frame, img });
+      };
+      return {
+        shapeCircle: get('circle', ({ frame }) => getComputedStyle(frame).borderRadius),
+        shapeRoundedRadius: get('rounded', ({ frame }) => getComputedStyle(frame).borderRadius),
+        mask: get('masked', ({ frame }) => getComputedStyle(frame).clipPath),
+        fitContain: get('fit-contain', ({ el, img }) => {
+          el.setAttribute('src', 'data:image/svg+xml;utf8,%3Csvg xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%2F%3E');
+          return img.style.objectFit;
+        }),
+        fitCover: get('fit-cover', ({ img }) => img.style.objectFit),
+        position: get('positioned', ({ el, img }) => {
+          el.setAttribute('src', 'data:image/svg+xml;utf8,%3Csvg xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%2F%3E');
+          return img.style.objectPosition;
+        }),
+        placeholder: get('placeholder', ({ el }) => el.shadowRoot.querySelector('.cap').textContent),
+        src: get('with-src', ({ img }) => img.getAttribute('src')),
+      };
+    });
+    assert.ok(/^(60px|50%)$/.test(wired.shapeCircle), `shape=circle borderRadius="${wired.shapeCircle}"`);
+    assert.match(wired.shapeRoundedRadius, /20px/);
+    assert.match(wired.mask, /polygon/);
+    // fit=cover is the default — image-slot enters a reframe path that
+    // strips object-fit from inline style. Pin the empty value so a
+    // regression to inline 'cover' (which would break the reframe
+    // behavior) gets caught.
+    assert.equal(wired.fitCover, '');
+    assert.equal(wired.fitContain, 'contain');
+    assert.match(wired.position, /20% 80%/);
+    assert.equal(wired.placeholder, 'Drop a hero');
+    assert.match(wired.src, /^data:image\/svg\+xml/);
+    await page.close();
+  });
+
+  // src resolves on first render (synchronous _render in connectedCallback),
+  // not asynchronously after a microtask flush. A regression to async wiring
+  // would briefly show the placeholder caption before paint.
+  test('image-slot src resolves synchronously on first render — no placeholder flash', async () => {
+    const page = await browser.newPage();
+    await page.goto(server.fixture('image-slot.html'));
+    await page.waitForFunction(() => !!customElements.get('image-slot'));
+    const state = await page.evaluate(() => {
+      const el = document.getElementById('with-src');
+      const img = el.shadowRoot.querySelector('img');
+      const empty = el.shadowRoot.querySelector('.empty');
+      return {
+        imgDisplay: img.style.display,
+        emptyDisplay: empty.style.display,
+        filled: el.hasAttribute('data-filled'),
+        imgSrc: img.getAttribute('src'),
+      };
+    });
+    assert.equal(state.filled, true, 'data-filled should be set on first render when src is present');
+    assert.equal(state.imgDisplay, 'block', 'inner img should be displayed on first render');
+    assert.equal(state.emptyDisplay, 'none', 'empty/placeholder state must be hidden when src is present');
+    assert.ok(state.imgSrc && state.imgSrc.length > 0);
+    await page.close();
+  });
+
+  // ── data-deck-skip ────────────────────────────────────────────────────
+  // Per the contract, a section flagged data-deck-skip is excluded from
+  // keyboard advance. Duplicate of deck-stage-rail.spec.js by design —
+  // dropping skip support must fail in the contract suite too.
+  test('data-deck-skip excludes a section from keyboard navigation', async () => {
+    const page = await browser.newPage();
+    await bootDeck(page, server.fixture('minimal-deck-skip.html'));
+    await page.keyboard.press('ArrowRight');
+    await page.keyboard.press('ArrowRight'); // hops over the skipped section
+    const idx = await page.evaluate(() => document.querySelector('deck-stage').index);
+    assert.notEqual(idx, 2, 'index 2 is data-deck-skip and must not be reached by keyboard nav');
+    await page.close();
+  });
+
+  // ── data-step-max / data-step step machine ────────────────────────────
+  // Step state is documented and owned by deck-stage. On a slide with
+  // data-step-max="N", ArrowRight increments data-step (0..N) and
+  // SWALLOWS the slide nav; once step == N, ArrowRight resumes slide
+  // advance. ArrowLeft mirrors. Slide change resets data-step to 0.
+  test('data-step-max: ArrowRight advances data-step before slide, then advances slide at max', async () => {
+    const page = await browser.newPage();
+    await bootDeck(page, server.fixture('stepped-deck.html'));
+    await page.evaluate(() => document.querySelector('deck-stage').goTo(1)); // land on the stepped slide
+    const step0 = await page.evaluate(() => document.querySelector('section[data-step-max]').getAttribute('data-step'));
+    assert.equal(step0, '0', 'step should be 0 on slide enter');
+
+    await page.keyboard.press('ArrowRight'); // step 0 → 1
+    let st = await page.evaluate(() => ({
+      idx: document.querySelector('deck-stage').index,
+      step: document.querySelector('section[data-step-max]').getAttribute('data-step'),
+    }));
+    assert.equal(st.idx, 1, 'still on stepped slide after first ArrowRight');
+    assert.equal(st.step, '1');
+
+    await page.keyboard.press('ArrowRight'); // step 1 → 2 (== max)
+    st = await page.evaluate(() => ({
+      idx: document.querySelector('deck-stage').index,
+      step: document.querySelector('section[data-step-max]').getAttribute('data-step'),
+    }));
+    assert.equal(st.idx, 1, 'still on stepped slide after reaching max step');
+    assert.equal(st.step, '2');
+
+    await page.keyboard.press('ArrowRight'); // step == max → slide advances
+    const idxAfter = await page.evaluate(() => document.querySelector('deck-stage').index);
+    assert.equal(idxAfter, 2, 'slide advances once step max is reached');
+    await page.close();
+  });
+
+  test('data-step-max: ArrowLeft retreats step before slide; slide change resets step', async () => {
+    const page = await browser.newPage();
+    await bootDeck(page, server.fixture('stepped-deck.html'));
+    await page.evaluate(() => document.querySelector('deck-stage').goTo(1));
+    // Walk to mid-step.
+    await page.keyboard.press('ArrowRight');
+    let step = await page.evaluate(() => document.querySelector('section[data-step-max]').getAttribute('data-step'));
+    assert.equal(step, '1');
+    // ArrowLeft retreats step, does not change slide.
+    await page.keyboard.press('ArrowLeft');
+    let st = await page.evaluate(() => ({
+      idx: document.querySelector('deck-stage').index,
+      step: document.querySelector('section[data-step-max]').getAttribute('data-step'),
+    }));
+    assert.equal(st.idx, 1);
+    assert.equal(st.step, '0');
+    // Step at 0 → ArrowLeft retreats slide.
+    await page.keyboard.press('ArrowLeft');
+    assert.equal(await page.evaluate(() => document.querySelector('deck-stage').index), 0);
+
+    // Re-enter the stepped slide via goTo, push it past 0, then leave —
+    // step must reset to 0 on slide change.
+    await page.evaluate(() => document.querySelector('deck-stage').goTo(1));
+    await page.keyboard.press('ArrowRight');
+    await page.evaluate(() => document.querySelector('deck-stage').goTo(2));
+    const stepAfter = await page.evaluate(() =>
+      document.querySelector('section[data-step-max]').getAttribute('data-step'),
+    );
+    assert.equal(stepAfter, '0', 'slide change resets data-step to 0');
+    await page.close();
+  });
+
+  // R is documented as "reset to slide 1 step 0" — verify the step half.
+  test('R resets to slide 0 AND clears data-step on the stepped slide', async () => {
+    const page = await browser.newPage();
+    await bootDeck(page, server.fixture('stepped-deck.html'));
+    await page.evaluate(() => document.querySelector('deck-stage').goTo(1));
+    await page.keyboard.press('ArrowRight'); // step → 1
+    await page.evaluate(() => document.querySelector('deck-stage').goTo(2));
+    // Re-enter and bump step before pressing R.
+    await page.evaluate(() => document.querySelector('deck-stage').goTo(1));
+    await page.keyboard.press('ArrowRight');
+    await page.keyboard.press('r');
+    const idx = await page.evaluate(() => document.querySelector('deck-stage').index);
+    const step = await page.evaluate(() =>
+      document.querySelector('section[data-step-max]').getAttribute('data-step'),
+    );
+    assert.equal(idx, 0);
+    assert.equal(step, '0');
+    await page.close();
+  });
+
+  // R must reset data-step on the current slide even when already on
+  // slide 0. Without this guard, _go(0) short-circuits when index===0 and
+  // skips _applyIndex's step-reset, leaving an opening stepped slide
+  // stuck mid-reveal.
+  test('R resets data-step on the current slide even when already on slide 0', async () => {
+    const page = await browser.newPage();
+    await bootDeck(page, server.fixture('stepped-deck-first.html'));
+    // Land on the stepped first slide and walk past step 0.
+    await page.keyboard.press('ArrowRight'); // step 0 → 1
+    let step = await page.evaluate(() => document.querySelector('section[data-step-max]').getAttribute('data-step'));
+    assert.equal(step, '1');
+    // R while already on slide 0.
+    await page.keyboard.press('r');
+    const after = await page.evaluate(() => ({
+      idx: document.querySelector('deck-stage').index,
+      step: document.querySelector('section[data-step-max]').getAttribute('data-step'),
+    }));
+    assert.equal(after.idx, 0);
+    assert.equal(after.step, '0', 'R must reset data-step even when _go(0) short-circuits');
+    await page.close();
+  });
+
+  // Boundary cases for the documented contract: hash deep-link must
+  // reject out-of-range and non-integer values silently (no crash, no
+  // wrap, no land-on-undefined).
+  test('hash #N out-of-range integer is ignored (no crash, defaults to slide 0)', async () => {
+    const page = await browser.newPage();
+    await bootDeck(page, server.fixture('minimal-deck.html') + '#999');
+    assert.equal(await page.evaluate(() => document.querySelector('deck-stage').index), 0);
+    await page.close();
+  });
+
+  test('hash #N non-integer is ignored (no crash, defaults to slide 0)', async () => {
+    const page = await browser.newPage();
+    await bootDeck(page, server.fixture('minimal-deck.html') + '#abc');
+    assert.equal(await page.evaluate(() => document.querySelector('deck-stage').index), 0);
+    await page.close();
+  });
+
+  // data-step-max="0" must behave like a non-stepped slide (no key
+  // swallowing). The handler's `max > 0` guard at deck-stage.js makes
+  // this work today; a regression to `max >= 0` would swallow ArrowRight.
+  test('data-step-max="0" does not swallow advance keys', async () => {
+    const page = await browser.newPage();
+    await bootDeck(page, server.fixture('minimal-deck.html'));
+    await page.evaluate(() => {
+      const stage = document.querySelector('deck-stage');
+      stage.children[1].setAttribute('data-step-max', '0');
+      stage.goTo(1);
+    });
+    await page.keyboard.press('ArrowRight');
+    const idx = await page.evaluate(() => document.querySelector('deck-stage').index);
+    assert.equal(idx, 2, 'ArrowRight on data-step-max="0" must advance slide, not swallow');
+    await page.close();
+  });
+
+  // SECTION_DATA_ATTRS is the canonical README list — read it into the
+  // suite so a future refactor that drops an entry shows up here.
+  // The behavior tests above cover each name in turn.
+  test('SECTION_DATA_ATTRS matches the README-documented surface', () => {
+    assert.deepEqual(
+      [...SECTION_DATA_ATTRS].sort(),
+      ['data-deck-skip', 'data-label', 'data-step', 'data-step-max'],
+    );
   });
 });

--- a/tests/deck-kit/deck-stage.spec.js
+++ b/tests/deck-kit/deck-stage.spec.js
@@ -162,11 +162,12 @@ describe('deck-stage navigation', () => {
     await page.close();
   });
 
-  test('data-step-max / data-step pass through untouched (deck-kit does not clobber consumer attrs)', async () => {
-    // Step-reveal glue is deck-specific (rule #4: composition, not in
-    // deck-stage core). The contract from deck-stage's side is that
-    // sections carrying data-step-max / data-step are passed through
-    // verbatim — deck-kit must not remove, normalize, or overwrite them.
+  test('data-step-max never gets clobbered; data-step normalises to 0 on slide change', async () => {
+    // data-step-max is author-set markup; deck-stage must never modify
+    // it. data-step is owned by deck-stage's step machine: it resets to
+    // 0 whenever the slide gains or loses focus (so re-entries replay
+    // cleanly). Behavior of the step machine itself lives in
+    // contract.spec.js — this test just guards the attribute lifecycle.
     const page = await browser.newPage();
     await bootDeck(page, server.fixture('stepped-deck.html'));
     const state = await page.evaluate(() => {
@@ -182,15 +183,14 @@ describe('deck-stage navigation', () => {
     assert.equal(state.hasStep, true);
     assert.equal(state.stepMax, '2');
     assert.equal(state.step, '0');
-    // Nav around a stepped slide; attributes must survive.
     await page.evaluate(() => document.querySelector('deck-stage').goTo(1));
     await page.evaluate(() => document.querySelector('deck-stage').goTo(2));
     const after = await page.evaluate(() => {
       const stepped = document.querySelector('section[data-step-max]');
       return { stepMax: stepped.getAttribute('data-step-max'), step: stepped.getAttribute('data-step') };
     });
-    assert.equal(after.stepMax, '2');
-    assert.equal(after.step, '0');
+    assert.equal(after.stepMax, '2', 'data-step-max is author-set and must survive nav');
+    assert.equal(after.step, '0', 'data-step resets to 0 on slide leave/enter');
     await page.close();
   });
 

--- a/tests/deck-kit/fixtures/stepped-deck-first.html
+++ b/tests/deck-kit/fixtures/stepped-deck-first.html
@@ -1,0 +1,17 @@
+<!doctype html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>stepped-deck-first fixture</title>
+<style>deck-stage:not(:defined){visibility:hidden}</style>
+</head>
+<body>
+<deck-stage width="1920" height="1080">
+  <section data-label="Opener" data-step-max="2" data-step="0"><h1>opener</h1></section>
+  <section data-label="Two"><h1>2</h1></section>
+  <section data-label="Three"><h1>3</h1></section>
+</deck-stage>
+<script src="/static/deck-kit/image-slot.js" defer></script>
+<script src="/static/deck-kit/deck-stage.js" defer></script>
+</body>
+</html>


### PR DESCRIPTION
## Summary

Completes the deck-kit API contract:

- `static/deck-kit/README.md` gains a **Supported API surface** section enumerating every shipped `<deck-stage>` attribute, `<section>` `data-*` attribute, keyboard binding, URL hash route, `<image-slot>` attribute, `<image-slot>` CSS hook (`[data-filled]` and `::part(frame|image|empty|ring)`), event detail shape, and JS API member.
- `tests/deck-kit/contract.spec.js` adds ~15 sanity assertions covering each documented surface — `#N` hash deep-link (+ out-of-range + non-integer boundaries), every keyboard binding (incl. `F` and `0`), per-attribute `<image-slot>` wiring, `src`-resolves-before-paint, `data-deck-skip` keyboard nav, the step machine end-to-end, `R` on the first slide, `data-step-max="0"` no-op.
- The step-reveal handler (`data-step-max` / `data-step`) is **promoted from the DevTalks deck's inline IIFE into `deck-stage.js`** so the README isn't documenting a feature deck-kit doesn't own. Folded into `_onKey` (intercepts advance/retreat when the active slide has `data-step-max`, bumps `data-step` until it hits max, then falls through to slide nav); reset of `data-step` lives in `_applyIndex` on every slide transition. `Enter` joins the advance-key set. `R` is special-cased to reset `data-step` on the current slide even when `_go(0)` short-circuits because index is already 0. `BUTTON` joins the form-field guard so light-DOM author buttons keep native Enter/Space semantics.
- `static/presentations/2026-devtalks-romania/index.html` strips the inline ~90-line step machine down to just the `.s-amplifier` `data-step-max="1"` auto-stamping (deck-specific, kept inline per rule #4).

Three peer-reviewer findings (R-doesn't-reset-step-on-slide-0, dead `fitCover` assertion, `Enter`-vs-focused-button) addressed in the same PR; one Important finding (`data-step` resets on slide leave, so over-shooting loses reveal state) is documented behavior per README.

## Test plan

- [x] \`npm run test:deck-kit\` → 59 pass / 0 fail (was 44 pre-PR).
- [x] \`npm run snapshot:baseline\` + \`npm run snapshot:diff\` against the DevTalks deck → 30/30 slides pixel-identical to baseline (no visual regression from promoting the step machine).
- [ ] Reviewer: walk a stepped slide in the live DevTalks deck (ArrowRight advances step, ArrowRight at max advances slide, ArrowLeft retreats step, R resets) — sanity check that the promotion preserves the speaker-facing UX.

Fixes manusa/com.marcnuri.automated-tasks#1815