### PR TITLE
🐛 scripts: make snapshot/screenshot walker step-aware

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -33,6 +33,14 @@ Visiting `/` shows a dev-only index of every deck under `static/presentations/`,
 
 **Cleanup is automatic** for Claude Code sessions. The wrapper also writes `.live-server.pid`; the Stop hook in `.claude/settings.json` runs `npm run --silent serve:static:stop` when the session ends, which reads the PID, verifies it still belongs to a `live-server` process (scoped check so it never kills another worktree's server), terminates it, and removes both sidecar files. Outside a Claude session, run the same command manually: `npm run serve:static:stop`.
 
+**Deep-linking to a slide** — static decks accept a `#<N>` hash on initial load (1-indexed) to land on section N. Useful when iterating on one slide so the browser re-opens where you left off:
+
+```
+http://localhost:$(cat .live-server.port)/presentations/<slug>/#19
+```
+
+This is part of the deck-kit contract (`static/deck-kit/README.md` § URL hash). The `screenshot` script exposes the same entry point via `--slide N [--step K]` for one-shot captures of a specific (section, step) state without manual ArrowRight clicking.
+
 ## Visual Review (Screenshots + PDF)
 
 Four Playwright-backed scripts produce visual artifacts. All output goes under `./screenshots/` (gitignored). All capture at 1920×1080.
@@ -48,9 +56,14 @@ npm run screenshot -- http://localhost:8000/ landing
 npm run screenshot -- http://localhost:$(cat .live-server.port)/presentations/<slug>/ early-state --delay 200
 ```
 
-**Whole deck → PNG per slide** — `screenshot:deck`. Walks a `<deck-stage>`-style deck via `ArrowRight` keypress, captures each slide after animations settle. Outputs `screenshots/<name>/slide-NN.png`.
+**Whole deck → PNG per (section, step)** — `screenshot:deck`. Walks a `<deck-stage>`-style deck via `ArrowRight` keypress, captures each (section, step) state after animations settle. Outputs `screenshots/<name>/slide-NN.png` for non-stepped sections and `screenshots/<name>/slide-NN-step-K.png` for sections with `data-step-max`.
 ```bash
 npm run screenshot:deck -- http://localhost:$(cat .live-server.port)/presentations/2026-devtalks-romania/ devtalks-current
+```
+
+**Single slide at a specific step** — `screenshot --slide N [--step K]`. Loads the deck, jumps to section N (1-indexed), advances to step K, captures. Equivalent to loading the URL with the `#N` hash plus K manual `ArrowRight` presses, without the manual clicking.
+```bash
+npm run screenshot -- http://localhost:$(cat .live-server.port)/presentations/2026-devtalks-romania/ s19-step1 --slide 19 --step 1
 ```
 
 **Whole deck → multi-page PDF** — `export:pdf`. Renders straight to a 1920×1080 vector PDF via Chromium's `page.pdf()` against the deck's `@media print` rule — text remains selectable, file size stays small (no rasterised slides). Photographic WebP `<image-slot>` sources are transcoded to JPEG just-in-time before render, because PDF doesn't support WebP and would otherwise embed each one as a multi-megabyte FlateDecode bitmap. Hand the output to conference organizers who require PDF.
@@ -58,9 +71,9 @@ npm run screenshot:deck -- http://localhost:$(cat .live-server.port)/presentatio
 npm run export:pdf -- http://localhost:$(cat .live-server.port)/presentations/2026-devtalks-romania/ /tmp/devtalks-2026.pdf
 ```
 
-**Step-aware capture**: a `<section>` that publishes `data-step-max="N"` becomes N+1 PDF pages, rendered at `data-step="0..N"`. This is the contract `.s-amplifier` uses (3 states per slide); any future stepping slide should follow it and `export:pdf` will pick it up with no code changes.
+**Step-aware capture**: a `<section>` that publishes `data-step-max="N"` becomes N+1 PDF pages (in `export:pdf`) and N+1 PNGs (in `screenshot:deck` / snapshot scripts), rendered at `data-step="0..N"`. This is the contract `.s-amplifier` uses (3 states per slide); any future stepping slide should follow it and all four scripts will pick it up with no code changes.
 
-`screenshot:deck` and the snapshot scripts walk the deck via **keyboard simulation** (`ArrowRight`) — agnostic of any specific `deck-stage` API, so they keep working as `deck-stage.js` evolves. `export:pdf` takes a different path (DOM-clone the step states, render once in print media) because per-slide PNGs can't preserve vector text or compress photos efficiently.
+`screenshot:deck` and the snapshot scripts walk the deck via **keyboard simulation** (`ArrowRight`) — agnostic of any specific `deck-stage` API, so they keep working as `deck-stage.js` evolves. The walker is step-aware: it discovers `(section, step)` pairs up front from `data-step-max` and presses ArrowRight once per pair, matching the deck's own step-reveal handler. `export:pdf` takes a different path (DOM-clone the step states, render once in print media) because per-slide PNGs can't preserve vector text or compress photos efficiently.
 
 ## Snapshot Regression Tests
 
@@ -138,7 +151,7 @@ Same pattern whether the change is supposed to be invisible (refactor) or very v
 2. **Before editing**: `npm run snapshot:baseline -- http://localhost:$(cat .live-server.port)/presentations/<slug>/ <deck-name>` to capture the "before" state.
 3. Edit files. Browser auto-reloads.
 4. `npm run snapshot:diff -- http://localhost:$(cat .live-server.port)/presentations/<slug>/ <deck-name>`.
-5. Review every flagged slide under `snapshots/<deck-name>/diff/slide-NN.png`. Confirm each delta matches intent:
+5. Review every flagged capture under `snapshots/<deck-name>/diff/slide-NN[-step-K].png`. Confirm each delta matches intent:
    - Refactor: expect 0 diffs. Any diff is a regression — investigate, don't shrug.
    - Visual change: expect diffs only on the slides you touched. Anything else is collateral damage.
 6. Commit code changes only. `snapshots/` is gitignored — nothing to add there.

--- a/scripts/lib/deck.js
+++ b/scripts/lib/deck.js
@@ -107,36 +107,108 @@ async function expandStepClones(page) {
 }
 
 /**
- * Walk a deck slide-by-slide via ArrowRight, calling `onSlide(i, total)`
- * after each slide's animations have settled.
+ * Walk a deck via ArrowRight, capturing every (section, step) pair.
  *
+ * Slides with `data-step-max="N"` expand to N+1 captures (steps 0..N) because
+ * the in-deck step-reveal handler intercepts ArrowRight until the slide is
+ * fully stepped, then passes it through to advance to the next section.
  * `onSlide` is awaited; throw from it to abort the walk.
  *
- * Returns the total number of slides captured.
+ * `onSlide(descriptor, totalPairs, captureIndex)` where descriptor is
+ *   { sectionIdx: 1-indexed section position,
+ *     step:       0-indexed step within section,
+ *     maxStep:    section's data-step-max (0 for non-stepped),
+ *     totalSections: raw <section> count (for filename padding) }.
+ *
+ * Returns the total number of (section, step) pairs captured.
  */
 async function walkDeck(page, onSlide) {
-  const total = await page.evaluate(() => {
+  const sequence = await page.evaluate(() => {
     const stage = document.querySelector('deck-stage');
-    if (!stage) return 0;
-    return stage.querySelectorAll(':scope > section').length;
+    if (!stage) return [];
+    const sections = Array.from(stage.querySelectorAll(':scope > section'));
+    const totalSections = sections.length;
+    const out = [];
+    sections.forEach((s, idx) => {
+      const max = parseInt(s.getAttribute('data-step-max') || '0', 10);
+      const maxStep = Number.isFinite(max) && max > 0 ? max : 0;
+      for (let step = 0; step <= maxStep; step++) {
+        out.push({sectionIdx: idx + 1, step, maxStep, totalSections});
+      }
+    });
+    return out;
   });
-  if (total === 0) {
+
+  if (sequence.length === 0) {
     throw new Error('No <deck-stage> > <section> elements found at this URL.');
   }
 
   await applyExportHidden(page);
 
-  for (let i = 1; i <= total; i++) {
-    if (i > 1) {
+  for (let i = 0; i < sequence.length; i++) {
+    if (i > 0) {
       await page.keyboard.press('ArrowRight');
       // Give the deck a tick to process the keypress before we look at animations.
       await page.waitForTimeout(100);
     }
     await settleAnimations(page);
-    await onSlide(i, total);
+    await onSlide(sequence[i], sequence.length, i + 1);
   }
 
-  return total;
+  return sequence.length;
 }
 
-module.exports = {settleAnimations, applyExportHidden, expandStepClones, walkDeck};
+/**
+ * Filename for a (section, step) capture descriptor produced by `walkDeck`.
+ * Stepped sections get `slide-NN-step-K.png`; non-stepped get `slide-NN.png`.
+ * Pad width is derived from `totalSections`, not the inflated pair count.
+ */
+function slideFilename({sectionIdx, step, maxStep, totalSections}) {
+  const pad = Math.max(2, String(totalSections).length);
+  const idx = String(sectionIdx).padStart(pad, '0');
+  return maxStep > 0 ? `slide-${idx}-step-${step}.png` : `slide-${idx}.png`;
+}
+
+/**
+ * Jump to (sectionIdx, step) on an already-loaded deck. sectionIdx is
+ * 1-indexed (matching the documented `#N` hash entry point). Uses the
+ * public deck-stage.goTo() API for the section jump, then K ArrowRight
+ * presses to advance the step. Settles between each press.
+ *
+ * Throws with a clear message if sectionIdx or step are out of range.
+ */
+async function goToStep(page, sectionIdx, step) {
+  const meta = await page.evaluate((n) => {
+    const stage = document.querySelector('deck-stage');
+    if (!stage) return {error: 'no-stage'};
+    const sections = Array.from(stage.querySelectorAll(':scope > section'));
+    if (n < 1 || n > sections.length) {
+      return {error: 'section-out-of-range', total: sections.length};
+    }
+    const s = sections[n - 1];
+    const max = parseInt(s.getAttribute('data-step-max') || '0', 10);
+    return {maxStep: Number.isFinite(max) && max > 0 ? max : 0, total: sections.length};
+  }, sectionIdx);
+  if (meta.error === 'no-stage') {
+    throw new Error('No <deck-stage> element found at this URL.');
+  }
+  if (meta.error === 'section-out-of-range') {
+    throw new Error(`--slide ${sectionIdx} is out of range (deck has ${meta.total} sections).`);
+  }
+  if (step < 0 || step > meta.maxStep) {
+    throw new Error(
+      `--step ${step} is out of range for section ${sectionIdx} (data-step-max=${meta.maxStep}).`
+    );
+  }
+  await page.evaluate((n) => {
+    document.querySelector('deck-stage').goTo(n - 1);
+  }, sectionIdx);
+  await settleAnimations(page);
+  for (let s = 0; s < step; s++) {
+    await page.keyboard.press('ArrowRight');
+    await page.waitForTimeout(100);
+  }
+  await settleAnimations(page);
+}
+
+module.exports = {settleAnimations, applyExportHidden, expandStepClones, walkDeck, slideFilename, goToStep};

--- a/scripts/screenshot-deck.js
+++ b/scripts/screenshot-deck.js
@@ -2,18 +2,19 @@
 /* eslint-disable no-console */
 const path = require('path');
 const fs = require('fs');
-const {walkDeck} = require('./lib/deck');
+const {walkDeck, slideFilename} = require('./lib/deck');
 
 const USAGE = `Usage: npm run screenshot:deck -- <deck-url> <name>
 
   <deck-url>  URL of a deck (single page containing <deck-stage> with <section> children)
   <name>      Output subdirectory name under screenshots/
 
-Captures one PNG per slide at 1920x1080:
-  ./screenshots/<name>/slide-01.png, slide-02.png, ...
+Captures one PNG per (section, step) at 1920x1080:
+  ./screenshots/<name>/slide-NN.png            for non-stepped sections
+  ./screenshots/<name>/slide-NN-step-K.png     for sections with data-step-max="N" (one PNG per step state)
 
 How it works:
-  - Loads the deck, counts <deck-stage> > <section> children
+  - Loads the deck, discovers (section, step) pairs from <deck-stage> > <section>[data-step-max]
   - Navigates via ArrowRight keypress (agnostic of any deck-stage internals)
   - Waits for non-looping CSS animations to finish before each capture
 
@@ -60,26 +61,14 @@ try {
     const page = await context.newPage();
     await page.goto(url, {waitUntil: 'networkidle', timeout: 30_000});
 
-    // We don't know the total until walkDeck queries it, but we want zero-padded
-    // filenames. Discover count up-front so pad width is known.
-    const total = await page.evaluate(() => {
-      const stage = document.querySelector('deck-stage');
-      return stage ? stage.querySelectorAll(':scope > section').length : 0;
-    });
-    if (total === 0) {
-      console.error('No <deck-stage> > <section> elements found at this URL.');
-      process.exit(1);
-    }
-    const padLen = Math.max(2, String(total).length);
-
-    console.log(`Capturing ${total} slides from ${url}`);
-    await walkDeck(page, async (i, n) => {
-      const outPath = path.join(outDir, `slide-${String(i).padStart(padLen, '0')}.png`);
+    console.log(`Capturing from ${url}`);
+    const total = await walkDeck(page, async (slide, totalPairs, captureIndex) => {
+      const outPath = path.join(outDir, slideFilename(slide));
       await page.screenshot({path: outPath, fullPage: false});
-      console.log(`  [${i}/${n}] ${outPath}`);
+      console.log(`  [${captureIndex}/${totalPairs}] ${outPath}`);
     });
 
-    console.log(`✓ ${total} slides → ${outDir}`);
+    console.log(`✓ ${total} captures → ${outDir}`);
   } finally {
     await browser.close();
   }

--- a/scripts/screenshot.js
+++ b/scripts/screenshot.js
@@ -2,19 +2,27 @@
 /* eslint-disable no-console */
 const path = require('path');
 const fs = require('fs');
-const {settleAnimations} = require('./lib/deck');
+const {settleAnimations, goToStep} = require('./lib/deck');
 
-const USAGE = `Usage: npm run screenshot -- <url> [name] [--delay <ms>]
+const USAGE = `Usage: npm run screenshot -- <url> [name] [--delay <ms>] [--slide N [--step K]]
 
   <url>           URL to capture (e.g. http://localhost:8000/presentations/2026-devtalks-romania)
   [name]          Output basename (default: screenshot-<timestamp>). The .png suffix is added automatically.
   [--delay <ms>]  Fixed wait after networkidle, instead of waiting for animations to settle.
                   Use this to capture a slide mid-animation (e.g. --delay 200 for an early frame).
+  [--slide N]     1-indexed section to jump to inside the deck before capturing. Uses the
+                  deck-stage public API; equivalent to loading the deck with hash #N.
+  [--step K]      0-indexed step within the section (requires --slide). Section must publish
+                  data-step-max >= K. Default 0.
+
+The deck-stage component also accepts a #<N> hash on initial load to deep-link to section N
+(1-indexed). The --slide/--step flags are a scripted equivalent for capture workflows.
 
 Examples:
   npm run screenshot -- http://localhost:8000/ landing
   npm run screenshot -- http://localhost:8000/.../slide-010-about mcp-about
   npm run screenshot -- http://localhost:$(cat .live-server.port)/presentations/2026-devtalks-romania/ early --delay 200
+  npm run screenshot -- http://localhost:$(cat .live-server.port)/presentations/2026-devtalks-romania/ s19-step1 --slide 19 --step 1
 
 Output:
   ./screenshots/<name>.png at 1920x1080.
@@ -26,6 +34,8 @@ First-time setup (downloads ~150MB):
 function parseArgs(rawArgs) {
   const positional = [];
   let delay = null;
+  let slide = null;
+  let step = null;
   for (let i = 0; i < rawArgs.length; i++) {
     const a = rawArgs[i];
     if (a === '--delay') {
@@ -35,6 +45,20 @@ function parseArgs(rawArgs) {
         process.exit(1);
       }
       delay = v;
+    } else if (a === '--slide') {
+      const v = parseInt(rawArgs[++i], 10);
+      if (Number.isNaN(v) || v < 1) {
+        console.error('--slide requires a positive integer (1-indexed section number).');
+        process.exit(1);
+      }
+      slide = v;
+    } else if (a === '--step') {
+      const v = parseInt(rawArgs[++i], 10);
+      if (Number.isNaN(v) || v < 0) {
+        console.error('--step requires a non-negative integer (0-indexed step within the section).');
+        process.exit(1);
+      }
+      step = v;
     } else if (a === '-h' || a === '--help') {
       console.log(USAGE);
       process.exit(0);
@@ -42,7 +66,11 @@ function parseArgs(rawArgs) {
       positional.push(a);
     }
   }
-  return {positional, delay};
+  if (step !== null && slide === null) {
+    console.error('--step requires --slide.');
+    process.exit(1);
+  }
+  return {positional, delay, slide, step};
 }
 
 const rawArgs = process.argv.slice(2);
@@ -50,7 +78,7 @@ if (rawArgs.length < 1) {
   console.log(USAGE);
   process.exit(1);
 }
-const {positional, delay} = parseArgs(rawArgs);
+const {positional, delay, slide, step} = parseArgs(rawArgs);
 const [url, rawName] = positional;
 if (!url) {
   console.error('Missing <url>.');
@@ -85,9 +113,20 @@ try {
   const page = await context.newPage();
   await page.goto(url, {waitUntil: 'networkidle', timeout: 30_000});
 
+  if (slide !== null) {
+    try {
+      await goToStep(page, slide, step == null ? 0 : step);
+    } catch (err) {
+      console.error(err.message || err);
+      await browser.close();
+      process.exit(1);
+    }
+  }
+
   if (delay !== null) {
     await page.waitForTimeout(delay);
-  } else {
+  } else if (slide === null) {
+    // goToStep already settled; only settle here for the no-jump path.
     await settleAnimations(page);
   }
 

--- a/scripts/snapshot-baseline.js
+++ b/scripts/snapshot-baseline.js
@@ -2,16 +2,18 @@
 /* eslint-disable no-console */
 const path = require('path');
 const fs = require('fs');
-const {walkDeck} = require('./lib/deck');
+const {walkDeck, slideFilename} = require('./lib/deck');
 
 const USAGE = `Usage: npm run snapshot:baseline -- <deck-url> <deck-name>
 
   <deck-url>   URL of a deck (single page containing <deck-stage> with <section> children)
   <deck-name>  Short slug used to namespace this deck's snapshots
 
-Writes one PNG per slide to snapshots/<deck-name>/baseline/slide-NN.png and OVERWRITES
-any existing baseline. The snapshots/ directory is gitignored — baselines are
-session-scoped reference points, not committed artifacts.
+Writes one PNG per (section, step) to snapshots/<deck-name>/baseline/:
+  slide-NN.png            for non-stepped sections
+  slide-NN-step-K.png     for sections with data-step-max (one PNG per step state)
+OVERWRITES any existing baseline. The snapshots/ directory is gitignored —
+baselines are session-scoped reference points, not committed artifacts.
 
 When to run:
   - Right before starting a change, to capture the "before" state for snapshot:diff
@@ -63,24 +65,14 @@ try {
     const page = await context.newPage();
     await page.goto(url, {waitUntil: 'networkidle', timeout: 30_000});
 
-    const total = await page.evaluate(() => {
-      const stage = document.querySelector('deck-stage');
-      return stage ? stage.querySelectorAll(':scope > section').length : 0;
-    });
-    if (total === 0) {
-      console.error('No <deck-stage> > <section> elements found at this URL.');
-      process.exit(1);
-    }
-    const padLen = Math.max(2, String(total).length);
-
-    console.log(`Capturing baseline for "${deckName}" — ${total} slides`);
-    await walkDeck(page, async (i, n) => {
-      const out = path.join(baselineDir, `slide-${String(i).padStart(padLen, '0')}.png`);
+    console.log(`Capturing baseline for "${deckName}"`);
+    const total = await walkDeck(page, async (slide, totalPairs, captureIndex) => {
+      const out = path.join(baselineDir, slideFilename(slide));
       await page.screenshot({path: out, fullPage: false});
-      console.log(`  [${i}/${n}] ${out}`);
+      console.log(`  [${captureIndex}/${totalPairs}] ${out}`);
     });
 
-    console.log(`✓ baseline written to ${baselineDir}`);
+    console.log(`✓ baseline written to ${baselineDir} (${total} captures)`);
     console.log(`  now make your changes, then: npm run snapshot:diff -- ${url} ${deckName}`);
   } finally {
     await browser.close();

--- a/scripts/snapshot-diff.js
+++ b/scripts/snapshot-diff.js
@@ -2,20 +2,20 @@
 /* eslint-disable no-console */
 const path = require('path');
 const fs = require('fs');
-const {walkDeck} = require('./lib/deck');
+const {walkDeck, slideFilename} = require('./lib/deck');
 
 const USAGE = `Usage: npm run snapshot:diff -- <deck-url> <deck-name>
 
   <deck-url>   URL of a deck (single page containing <deck-stage> with <section> children)
   <deck-name>  Short slug matching a previously-captured baseline
 
-Captures the deck's current state, then pixel-diffs each slide against the committed
-baseline at snapshots/<deck-name>/baseline/. Anti-aliasing differences are tolerated;
-real visual changes are surfaced.
+Captures the deck's current state, then pixel-diffs each (section, step) capture
+against the baseline at snapshots/<deck-name>/baseline/. Anti-aliasing differences
+are tolerated; real visual changes are surfaced.
 
-Outputs:
-  snapshots/<deck-name>/current/slide-NN.png   (gitignored — last capture)
-  snapshots/<deck-name>/diff/slide-NN.png      (gitignored — only when that slide differs)
+Outputs (mirrors the baseline filename scheme):
+  snapshots/<deck-name>/current/slide-NN[-step-K].png   (gitignored — last capture)
+  snapshots/<deck-name>/diff/slide-NN[-step-K].png      (gitignored — only when that capture differs)
 
 Console report: per-slide pixel diff count + %.
 Exit code: 0 if all slides identical, 1 if any differ (or slide count changed).
@@ -86,20 +86,10 @@ try {
     const page = await context.newPage();
     await page.goto(url, {waitUntil: 'networkidle', timeout: 30_000});
 
-    const total = await page.evaluate(() => {
-      const stage = document.querySelector('deck-stage');
-      return stage ? stage.querySelectorAll(':scope > section').length : 0;
-    });
-    if (total === 0) {
-      console.error('No <deck-stage> > <section> elements found at this URL.');
-      process.exit(1);
-    }
-    const padLen = Math.max(2, String(total).length);
-
-    console.log(`Capturing current state of "${deckName}" — ${total} slides`);
+    console.log(`Capturing current state of "${deckName}"`);
     const currentPaths = [];
-    await walkDeck(page, async (i, n) => {
-      const p = path.join(currentDir, `slide-${String(i).padStart(padLen, '0')}.png`);
+    const total = await walkDeck(page, async (slide) => {
+      const p = path.join(currentDir, slideFilename(slide));
       await page.screenshot({path: p, fullPage: false});
       currentPaths.push(p);
     });
@@ -155,13 +145,13 @@ try {
 
     console.log('');
     if (regressions === 0) {
-      console.log(`✓ all ${total} slides identical to baseline`);
+      console.log(`✓ all ${total} captures identical to baseline`);
       process.exit(0);
     } else {
-      console.log(`✗ ${regressions} slide(s) differ from baseline`);
-      if (extras.length) console.log(`  new slides:     ${extras.join(', ')}`);
-      if (missing.length) console.log(`  removed slides: ${missing.join(', ')}`);
-      console.log(`  diff overlays:  ${path.relative(process.cwd(), diffDir)}/`);
+      console.log(`✗ ${regressions} capture(s) differ from baseline`);
+      if (extras.length) console.log(`  new captures:     ${extras.join(', ')}`);
+      if (missing.length) console.log(`  removed captures: ${missing.join(', ')}`);
+      console.log(`  diff overlays:    ${path.relative(process.cwd(), diffDir)}/`);
       process.exit(1);
     }
   } finally {

--- a/tests/deck-kit/walker.spec.js
+++ b/tests/deck-kit/walker.spec.js
@@ -1,0 +1,135 @@
+'use strict';
+
+const { test, describe, before, after } = require('node:test');
+const assert = require('node:assert/strict');
+const { chromium } = require('playwright');
+const { startServer, bootDeck } = require('./_helpers');
+const { walkDeck } = require('../../scripts/lib/deck');
+
+describe('walkDeck (step-aware)', () => {
+  let server;
+  let browser;
+
+  before(async () => {
+    server = await startServer();
+    browser = await chromium.launch();
+  });
+
+  after(async () => {
+    if (browser) await browser.close();
+    if (server) await server.close();
+  });
+
+  // Inspect the deck's *runtime* state at the moment of each visit. This is
+  // the invariant that, when broken, produced the bug in issue #1814: the
+  // walker thought it was on (section i+1) while the deck was still on
+  // section i at a higher step. Asserting runtime state == descriptor at
+  // every visit locks down that the diff selectivity behavior follows.
+  async function snapshotRuntime(page) {
+    return page.evaluate(() => {
+      const stage = document.querySelector('deck-stage');
+      const sections = Array.from(stage.querySelectorAll(':scope > section'));
+      const active = sections.findIndex((s) => s.hasAttribute('data-deck-active'));
+      const step = active >= 0 ? parseInt(sections[active].getAttribute('data-step') || '0', 10) : -1;
+      return {activeSectionIdx: active + 1, dataStep: step};
+    });
+  }
+
+  test('visits each (section, step) pair exactly once on a stepped deck', async () => {
+    const page = await browser.newPage();
+    await bootDeck(page, server.fixture('stepped-deck.html'));
+
+    const visits = [];
+    const total = await walkDeck(page, async (slide, totalPairs, captureIndex) => {
+      const runtime = await snapshotRuntime(page);
+      visits.push({
+        sectionIdx: slide.sectionIdx,
+        step: slide.step,
+        maxStep: slide.maxStep,
+        totalSections: slide.totalSections,
+        totalPairs,
+        captureIndex,
+        runtime,
+      });
+    });
+
+    // stepped-deck.html: <section> + <section data-step-max="2"> + <section>
+    // → expected sequence is (1,0), (2,0), (2,1), (2,2), (3,0) = 5 captures.
+    assert.equal(total, 5, 'walkDeck should return the number of (section,step) pairs visited');
+    assert.deepEqual(
+      visits.map((v) => [v.sectionIdx, v.step]),
+      [[1, 0], [2, 0], [2, 1], [2, 2], [3, 0]],
+      'walks sections in order, exhausting steps before advancing'
+    );
+    // Descriptor surface — callers rely on these fields for filename + padding.
+    assert.equal(visits[0].totalSections, 3, 'totalSections = raw section count, not pair count');
+    assert.equal(visits[0].maxStep, 0, 'non-stepped section has maxStep=0');
+    assert.equal(visits[1].maxStep, 2, 'stepped section reports its data-step-max');
+    assert.equal(visits[1].totalPairs, 5);
+    assert.equal(visits[0].captureIndex, 1, 'captureIndex is 1-indexed');
+    assert.equal(visits[4].captureIndex, 5);
+    // Selectivity invariant — the actual bug guard. If the walker ever drifts
+    // off the active section/step, snapshot-diff false negatives/positives
+    // re-appear. This pins each descriptor against the live deck state.
+    for (const v of visits) {
+      assert.equal(v.runtime.activeSectionIdx, v.sectionIdx,
+        `at capture ${v.captureIndex}: descriptor says section ${v.sectionIdx}, deck is on ${v.runtime.activeSectionIdx}`);
+      assert.equal(v.runtime.dataStep, v.step,
+        `at capture ${v.captureIndex}: descriptor says step ${v.step}, deck data-step is ${v.runtime.dataStep}`);
+    }
+    await page.close();
+  });
+
+  test('stepped FIRST section: exhausts steps before advancing off the boot slide', async () => {
+    const page = await browser.newPage();
+    await bootDeck(page, server.fixture('stepped-deck-first.html'));
+
+    const visits = [];
+    const total = await walkDeck(page, async (slide, totalPairs, captureIndex) => {
+      const runtime = await snapshotRuntime(page);
+      visits.push({sectionIdx: slide.sectionIdx, step: slide.step, captureIndex, runtime});
+    });
+
+    // stepped-deck-first.html: <section data-step-max="2"> + <section> + <section>
+    // First captures land on the boot slide at step 0, 1, 2 — exercises the
+    // step-reveal handler against the initially-active slide rather than
+    // transitioning into a stepped slide from an adjacent one.
+    assert.equal(total, 5);
+    assert.deepEqual(
+      visits.map((v) => [v.sectionIdx, v.step]),
+      [[1, 0], [1, 1], [1, 2], [2, 0], [3, 0]],
+      'stepped-first deck walks step 0..N on section 1 before advancing'
+    );
+    for (const v of visits) {
+      assert.equal(v.runtime.activeSectionIdx, v.sectionIdx);
+      assert.equal(v.runtime.dataStep, v.step);
+    }
+    await page.close();
+  });
+
+  test('throws if no <deck-stage> > <section> elements present', async () => {
+    const page = await browser.newPage();
+    await page.goto(server.fixture('_blank.html'));
+    await assert.rejects(
+      () => walkDeck(page, async () => {}),
+      /No <deck-stage> > <section> elements/
+    );
+    await page.close();
+  });
+
+  test('plain deck: every visit is step=0, count equals section count', async () => {
+    const page = await browser.newPage();
+    await bootDeck(page, server.fixture('minimal-deck.html'));
+
+    const visits = [];
+    const total = await walkDeck(page, async (slide) => {
+      visits.push(slide);
+    });
+
+    assert.ok(total >= 2, 'minimal-deck has at least 2 sections');
+    assert.equal(total, visits[0].totalSections, 'plain deck → pair count equals section count');
+    assert.ok(visits.every((v) => v.step === 0), 'no stepped sections → every step is 0');
+    assert.ok(visits.every((v) => v.maxStep === 0), 'no stepped sections → every maxStep is 0');
+    await page.close();
+  });
+});


### PR DESCRIPTION
## Summary

- `walkDeck` now discovers `(section, step)` pairs up front and walks each one. Sections with `data-step-max="N"` expand to N+1 captures with filenames `slide-NN-step-K.png`; non-stepped sections keep `slide-NN.png`. This matches the `export:pdf` step-aware precedent.
- Adds `goToStep(page, sectionIdx, step)` and a `screenshot --slide N [--step K]` flag for one-shot captures of a specific (section, step) state, with clear out-of-range errors.
- New Playwright test (`tests/deck-kit/walker.spec.js`) pins the visit sequence against deck-stage runtime state (`data-deck-active` + `data-step`) so future drift between walker and step-reveal handler fails loudly.

## Why

The previous walker did one `ArrowRight` per iteration. The deck-stage step-reveal handler intercepts `ArrowRight` on stepped sections until the slide is fully stepped, so each stepped slide consumed one extra iteration. The walker drifted by +1 per stepped slide ahead of it: false positives at the tail (`slide-28/29/30 differ 45%`), false negatives at any inserted/edited slide past the first stepped section. The verification workflow in `AGENTS.md` § 2 quietly stopped working as the deck accumulated stepped sections.

## Verified

- `npm run test:deck-kit` → 67/67 pass (4 new walker tests).
- `2026-devtalks-romania` deck (30 sections, 9 stepped → 40 captures): clean baseline → `✓ all 40 captures identical`.
- Edit slide 19 (data-step-max=1) → flags exactly `slide-19-step-0.png` and `slide-19-step-1.png`; all other 38 captures identical.
- `screenshot --slide 19 --step 1` produces a distinct capture from `--step 0` (different md5).
- `--slide 999` / `--step 99` / `--step` without `--slide` all exit non-zero with clear messages.
- `export:pdf` still produces 40 pages at 6.7MB (no shared code with `walkDeck`).

## Test plan

- [x] `npm run test:deck-kit` passes
- [x] `npm run snapshot:baseline` followed by `npm run snapshot:diff` on a clean tree reports 0 diffs
- [x] Editing one stepped slide flags only that slide's step captures
- [x] `npm run screenshot -- ... --slide N --step K` works on stepped slides
- [x] `npm run export:pdf` output is functionally unchanged

## Out of scope

Per the issue's "Out of scope" list — walker stays keyboard-driven (not migrated to `_index` / hash nav); one PNG per step state (no composite); snapshots stay gitignored; no new test runner; `expandStepClones` and `walkDeck` remain separate code paths.

Fixes manusa/com.marcnuri.automated-tasks#1814