### PR TITLE
✨ devtalks-2026: refresh slide 17 (specs vs tests) + 2-step reveal

### DIFF
--- a/static/presentations/2026-devtalks-romania/index.html
+++ b/static/presentations/2026-devtalks-romania/index.html
@@ -2116,7 +2116,7 @@ tasks.<span class="t-fn">register</span>(<span class="t-str">"quickBuild"</span>
        (a real fabric8 invariant). The form difference is the
        entire point of the slide.
        ============================================================ -->
-  <section class="s-specs-vs-tests light" data-label="17 Act 5 — Specs explain intent. Tests enforce it.">
+  <section class="s-specs-vs-tests light" data-label="17 Act 5 — Specs explain intent. Tests enforce it." data-step-max="1">
     <div class="chrome-top">
       <span class="dot"></span>
       <span>~/dev/devtalks-2026 · devtalks-act-05-codebase-feedback/SpecsVsTests.java</span>
@@ -2127,7 +2127,10 @@ tasks.<span class="t-fn">register</span>(<span class="t-str">"quickBuild"</span>
     <div class="body">
       <header class="head">
         <div class="eyebrow">// act 05 · the codebase pushes back</div>
-        <h2 class="title">Specs <em>explain</em> intent. Tests <em>enforce</em> it.</h2>
+        <!-- Two-step reveal: step 0 shows only "Specs explain intent." (the
+             problem framing); step 1 reveals "Tests enforce it." alongside
+             the test card on the right. -->
+        <h2 class="title">Specs <em>explain</em> intent. <span class="title-tail">Tests <em>enforce</em> it.</span></h2>
         <p class="sub">
           But <span class="t-warn">text doesn't push back.</span>
         </p>
@@ -2146,14 +2149,14 @@ tasks.<span class="t-fn">register</span>(<span class="t-str">"quickBuild"</span>
             <span class="enforce-pill advisory">// advisory</span>
           </header>
           <div class="panel-body">
-            <div class="ln md-h"># Default namespace</div>
+            <div class="ln md-h"># Default API server</div>
             <div class="ln sep"></div>
-            <div class="ln prose">When no namespace is configured,</div>
-            <div class="ln prose">fall back to <code>kubernetes.default.svc</code>.</div>
+            <div class="ln prose">When no API server URL is configured,</div>
+            <div class="ln prose">fall back to <code>https://kubernetes.default.svc/</code>.</div>
             <div class="ln sep"></div>
             <div class="ln cmt">// an agent may read this.</div>
             <div class="ln cmt">// or skip it.</div>
-            <div class="ln cmt">// or break it. and not notice.</div>
+            <div class="ln cmt">// or break it and still get a green build.</div>
           </div>
         </article>
 
@@ -2184,10 +2187,9 @@ tasks.<span class="t-fn">register</span>(<span class="t-str">"quickBuild"</span>
           <div class="panel-body code">
             <div class="ln"><span class="t-anno">@Test</span></div>
             <div class="ln"><span class="t-anno">@DisplayName</span>(<span class="t-str">"falls back to kubernetes.default.svc"</span>)</div>
-            <div class="ln"><span class="t-kw">void</span> <span class="t-fn">fallsBackToDefaultNamespace</span>() {</div>
-            <div class="ln indent">assertThat(<span class="t-kw">new</span> <span class="t-type">ConfigBuilder</span>().build())</div>
-            <div class="ln indent-2">.hasFieldOrPropertyWithValue(</div>
-            <div class="ln indent-3"><span class="t-str">"masterUrl"</span>, <span class="t-str">"https://kubernetes.default.svc/"</span>);</div>
+            <div class="ln"><span class="t-kw">void</span> <span class="t-fn">fallsBackToDefaultApiServer</span>() {</div>
+            <div class="ln indent">assertThat(<span class="t-kw">new</span> <span class="t-type">ConfigBuilder</span>().build().<span class="t-fn">getMasterUrl</span>())</div>
+            <div class="ln indent-2">.isEqualTo(<span class="t-str">"https://kubernetes.default.svc/"</span>);</div>
             <div class="ln">}</div>
           </div>
           <!-- Inline failure console — what the agent sees when wrong. -->
@@ -2195,10 +2197,10 @@ tasks.<span class="t-fn">register</span>(<span class="t-str">"quickBuild"</span>
             <div class="cf-head">
               <span class="cf-glyph">✗</span>
               <span class="cf-label">BUILD FAILED</span>
-              <span class="cf-sub">— ConfigTest › falls back to kubernetes.default.svc</span>
+              <span class="cf-sub">- ConfigTest &gt; falls back to kubernetes.default.svc</span>
             </div>
-            <div class="cf-detail">  <span class="cf-key">expected:</span> <span class="cf-ok">"https://kubernetes.default.svc/"</span></div>
-            <div class="cf-detail">  <span class="cf-key">actual:</span>   <span class="cf-bad">"https://my-cluster.example.com/"</span></div>
+            <div class="cf-detail"><span class="cf-key">expected:</span> <span class="cf-ok">"https://kubernetes.default.svc/"</span></div>
+            <div class="cf-detail"><span class="cf-key">actual:</span>   <span class="cf-bad">"https://my-cluster.example.com/"</span></div>
             <div class="cf-foot">// what the agent sees when it gets it wrong.</div>
           </div>
         </article>
@@ -2207,7 +2209,7 @@ tasks.<span class="t-fn">register</span>(<span class="t-str">"quickBuild"</span>
       <div class="tag-line">
         <span class="lbl">// takeaway</span>
         <div class="quote">
-          In Java, the best spec is the one that <em>compiles</em>.
+          In Java, the best spec <em>compiles, runs, and fails loudly.</em>
           <span class="sub">// text waits to be read. tests run on every commit.</span>
         </div>
       </div>

--- a/static/presentations/2026-devtalks-romania/index.html
+++ b/static/presentations/2026-devtalks-romania/index.html
@@ -2188,7 +2188,8 @@ tasks.<span class="t-fn">register</span>(<span class="t-str">"quickBuild"</span>
             <div class="ln"><span class="t-anno">@Test</span></div>
             <div class="ln"><span class="t-anno">@DisplayName</span>(<span class="t-str">"falls back to kubernetes.default.svc"</span>)</div>
             <div class="ln"><span class="t-kw">void</span> <span class="t-fn">fallsBackToDefaultApiServer</span>() {</div>
-            <div class="ln indent">assertThat(<span class="t-kw">new</span> <span class="t-type">ConfigBuilder</span>().build().<span class="t-fn">getMasterUrl</span>())</div>
+            <div class="ln indent"><span class="t-kw">var</span> config = <span class="t-kw">new</span> <span class="t-type">ConfigBuilder</span>().build();</div>
+            <div class="ln indent">assertThat(config.<span class="t-fn">getMasterUrl</span>())</div>
             <div class="ln indent-2">.isEqualTo(<span class="t-str">"https://kubernetes.default.svc/"</span>);</div>
             <div class="ln">}</div>
           </div>

--- a/static/presentations/2026-devtalks-romania/styles/s-specs-vs-tests.css
+++ b/static/presentations/2026-devtalks-romania/styles/s-specs-vs-tests.css
@@ -92,8 +92,12 @@
   display: grid;
   grid-template-columns: minmax(0, 1fr) 80px minmax(0, 1fr);
   column-gap: 0;
-  align-items: stretch;
+  /* Cards sit at their natural height so the right (test) card doesn't
+     get an empty dark band when the spec card on the left is taller.
+     The vs-axis is forced to stretch so the rail still spans the row. */
+  align-items: start;
 }
+.s-specs-vs-tests .vs-axis { align-self: stretch; }
 
 /* ---------- VS axis ---------- */
 .s-specs-vs-tests .vs-axis {
@@ -228,7 +232,10 @@
    ============================================================ */
 .s-specs-vs-tests .card-test {
   background: #060D3A;
-  border: 1px solid rgba(10, 21, 84, 0.30);
+  /* 3px to match the spec card's dashed border so the two panel-bars
+     share an optical top edge (border-box pushes the bar content down
+     by the border thickness). Solid vs dashed still distinguishes them. */
+  border: 3px solid rgba(10, 21, 84, 0.30);
   box-shadow:
     0 24px 60px rgba(10, 21, 84, 0.22),
     0 4px 12px rgba(10, 21, 84, 0.10);
@@ -247,20 +254,21 @@
 .s-specs-vs-tests .card-test .panel-bar.term .path { margin-left: 14px; color: #B4BAD8; }
 
 .s-specs-vs-tests .card-test .panel-body.code {
-  padding: 22px 30px 24px;
+  padding: 26px 30px 28px;
   font-family: 'JetBrains Mono', monospace;
-  font-size: 20px;
-  line-height: 1.45;
+  font-size: 23px;
+  line-height: 1.5;
   color: #C8CCE4;
   display: flex;
   flex-direction: column;
-  gap: 1px;
+  gap: 2px;
   white-space: nowrap;
   overflow: hidden;
+  text-overflow: ellipsis;
 }
-.s-specs-vs-tests .card-test .ln.indent   { padding-left: 22px; }
-.s-specs-vs-tests .card-test .ln.indent-2 { padding-left: 44px; }
-.s-specs-vs-tests .card-test .ln.indent-3 { padding-left: 66px; }
+.s-specs-vs-tests .card-test .ln.indent   { padding-left: 26px; }
+.s-specs-vs-tests .card-test .ln.indent-2 { padding-left: 52px; }
+.s-specs-vs-tests .card-test .ln.indent-3 { padding-left: 78px; }
 
 .s-specs-vs-tests .card-test .t-anno { color: var(--orange-soft); }
 .s-specs-vs-tests .card-test .t-kw   { color: #B89AE8; }
@@ -272,37 +280,37 @@
 .s-specs-vs-tests .card-test .console-fail {
   border-top: 1px solid rgba(255,255,255,0.08);
   background: linear-gradient(to bottom, rgba(240,42,90,0.10), rgba(240,42,90,0.04));
-  padding: 16px 30px 18px;
+  padding: 20px 30px 22px;
   font-family: 'JetBrains Mono', monospace;
-  font-size: 17px;
+  font-size: 20px;
   line-height: 1.5;
   color: #E8C8CF;
   display: flex;
   flex-direction: column;
-  gap: 2px;
+  gap: 3px;
 }
 .s-specs-vs-tests .card-test .console-fail .cf-head {
   display: flex;
   align-items: baseline;
   gap: 10px;
   flex-wrap: wrap;
-  margin-bottom: 4px;
+  margin-bottom: 8px;
 }
 .s-specs-vs-tests .card-test .console-fail .cf-glyph {
   color: var(--pink);
   font-weight: 700;
-  font-size: 20px;
+  font-size: 24px;
 }
 .s-specs-vs-tests .card-test .console-fail .cf-label {
   color: #FF6B7E;
   font-weight: 700;
   letter-spacing: 0.10em;
   text-transform: uppercase;
-  font-size: 16px;
+  font-size: 19px;
 }
 .s-specs-vs-tests .card-test .console-fail .cf-sub {
   color: #B4BAD8;
-  font-size: 15px;
+  font-size: 18px;
 }
 .s-specs-vs-tests .card-test .console-fail .cf-detail {
   color: #C8CCE4;
@@ -316,10 +324,10 @@
 .s-specs-vs-tests .card-test .console-fail .cf-ok  { color: #8FD79F; }
 .s-specs-vs-tests .card-test .console-fail .cf-bad { color: #FF8794; text-decoration: line-through; text-decoration-color: rgba(255,135,148,0.5); }
 .s-specs-vs-tests .card-test .console-fail .cf-foot {
-  margin-top: 10px;
+  margin-top: 14px;
   color: #8A93BC;
   font-style: italic;
-  font-size: 17px;
+  font-size: 19px;
 }
 
 /* ============================================================
@@ -362,9 +370,42 @@
 }
 
 /* ============================================================
+   Two-step reveal.
+
+   step 0 (problem)    — spec card + "Specs explain intent." +
+                         "But text doesn't push back."
+   step 1 (resolution) — adds "Tests enforce it.", vs axis,
+                         test card with BUILD FAILED, takeaway.
+
+   Hidden elements stay in the layout (opacity-only) so the
+   spec card and title don't reflow when step 1 fires.
+   ============================================================ */
+.s-specs-vs-tests .title-tail,
+.s-specs-vs-tests .vs-axis,
+.s-specs-vs-tests .card-test,
+.s-specs-vs-tests .tag-line {
+  opacity: 0;
+  transform: translateY(8px);
+  transition: opacity 400ms ease, transform 400ms ease;
+}
+.s-specs-vs-tests .title-tail { transform: none; }   /* inline; no rise */
+
+.s-specs-vs-tests[data-step="1"] .title-tail,
+.s-specs-vs-tests[data-step="1"] .vs-axis,
+.s-specs-vs-tests[data-step="1"] .card-test,
+.s-specs-vs-tests[data-step="1"] .tag-line {
+  opacity: 1;
+  transform: none;
+}
+.s-specs-vs-tests[data-step="1"] .vs-axis    { transition-delay: 80ms; }
+.s-specs-vs-tests[data-step="1"] .card-test  { transition-delay: 120ms; }
+.s-specs-vs-tests[data-step="1"] .tag-line   { transition-delay: 240ms; }
+
+/* ============================================================
    Print — drop shadows / gradient so Chromium's page.pdf()
-   doesn't rasterise them as opaque rectangles. The slide is
-   single-state so no step rules to flatten.
+   doesn't rasterise them as opaque rectangles. Step rendering
+   (export:pdf walks data-step="0..N") needs each state legible
+   without animation, which the opacity rules above already give.
    ============================================================ */
 @media print {
   .s-specs-vs-tests .card-spec,
@@ -372,4 +413,8 @@
   .s-specs-vs-tests .card-test .console-fail {
     background: rgba(240,42,90,0.10);
   }
+  .s-specs-vs-tests .title-tail,
+  .s-specs-vs-tests .vs-axis,
+  .s-specs-vs-tests .card-test,
+  .s-specs-vs-tests .tag-line { transition: none; }
 }

--- a/static/presentations/2026-devtalks-romania/styles/s-specs-vs-tests.css
+++ b/static/presentations/2026-devtalks-romania/styles/s-specs-vs-tests.css
@@ -277,12 +277,16 @@
 .s-specs-vs-tests .card-test .t-str  { color: #B6E3A8; }
 
 /* ---------- inline BUILD FAILED console (under the @Test body) ---------- */
+/* The failure console is the punchline of the slide ("what the agent
+   sees when it gets it wrong") — sizes are deliberately on the larger
+   side of the panel's typographic scale to stay legible on a conference
+   projector from 10+ metres back. */
 .s-specs-vs-tests .card-test .console-fail {
   border-top: 1px solid rgba(255,255,255,0.08);
   background: linear-gradient(to bottom, rgba(240,42,90,0.10), rgba(240,42,90,0.04));
-  padding: 20px 30px 22px;
+  padding: 22px 30px 24px;
   font-family: 'JetBrains Mono', monospace;
-  font-size: 20px;
+  font-size: 22px;
   line-height: 1.5;
   color: #E8C8CF;
   display: flex;
@@ -299,18 +303,18 @@
 .s-specs-vs-tests .card-test .console-fail .cf-glyph {
   color: var(--pink);
   font-weight: 700;
-  font-size: 24px;
+  font-size: 26px;
 }
 .s-specs-vs-tests .card-test .console-fail .cf-label {
   color: #FF6B7E;
   font-weight: 700;
   letter-spacing: 0.10em;
   text-transform: uppercase;
-  font-size: 19px;
+  font-size: 22px;
 }
 .s-specs-vs-tests .card-test .console-fail .cf-sub {
   color: #B4BAD8;
-  font-size: 18px;
+  font-size: 20px;
 }
 .s-specs-vs-tests .card-test .console-fail .cf-detail {
   color: #C8CCE4;
@@ -327,7 +331,7 @@
   margin-top: 14px;
   color: #8A93BC;
   font-style: italic;
-  font-size: 19px;
+  font-size: 20px;
 }
 
 /* ============================================================


### PR DESCRIPTION
## Summary

- Reframes the Act V opener (slide 17) around the default API server
  URL fallback (was "namespace", which was inaccurate). Rewrites
  trailing comments, simplifies the JUnit assertion to a getter call
  split across a `var config = ...` line, and replaces the takeaway
  with "In Java, the best spec compiles, runs, and fails loudly."
- Adds a 2-step reveal: step 0 sets up the problem (spec card +
  "Specs explain intent." + "But text doesn't push back."); step 1
  reveals "Tests enforce it.", the vs rail, the test card with
  BUILD FAILED, and the takeaway. Hidden elements stay in the layout
  (opacity-only) so the spec card doesn't reflow between steps.
- Projector legibility pass: bigger code/console fonts, right card
  no longer stretches to the spec card's height (no more dark dead
  band at the bottom), test card border bumped to 3px solid so both
  panel-bars share an optical top edge.

## Test plan

- [x] `snapshot:diff` clean (only slide-18 captures changed,
      intentionally)
- [x] Both step states rendered at 1920×1080 and reviewed
- [x] UX review pass (typography, contrast, layout)
- [ ] Sanity-check `export:pdf` output before the talk