### PR TITLE
✨ devtalks-2026: link real-world references (web + PDF)

### DIFF
--- a/static/presentations/2026-devtalks-romania/index.html
+++ b/static/presentations/2026-devtalks-romania/index.html
@@ -265,6 +265,7 @@
               <div class="proj-stack">
 
                 <div class="proj-card wide">
+                  <a class="ref-link overlay" href="https://github.com/containers/kubernetes-mcp-server" target="_blank" rel="noopener noreferrer" aria-label="kubernetes-mcp-server on GitHub"></a>
                   <image-slot id="logo-mcp-server" class="picon" fit="contain" src="assets/logos/containers.png" placeholder="logo"></image-slot>
                   <div class="pinfo">
                     <div class="pname">kubernetes-mcp-server</div>
@@ -277,6 +278,7 @@
                 </div>
 
                 <div class="proj-card wide">
+                  <a class="ref-link overlay" href="https://github.com/fabric8io/kubernetes-client" target="_blank" rel="noopener noreferrer" aria-label="fabric8 kubernetes-client on GitHub"></a>
                   <image-slot id="logo-k8s-client" class="picon" fit="contain" src="assets/logos/fabric8io.svg" placeholder="logo"></image-slot>
                   <div class="pinfo">
                     <div class="pname">fabric8 kubernetes-client</div>
@@ -289,6 +291,7 @@
                 </div>
 
                 <div class="proj-card wide">
+                  <a class="ref-link overlay" href="https://github.com/eclipse-jkube/jkube" target="_blank" rel="noopener noreferrer" aria-label="Eclipse JKube on GitHub"></a>
                   <image-slot id="logo-jkube" class="picon" fit="contain" src="assets/logos/eclipse-jkube.png" placeholder="logo"></image-slot>
                   <div class="pinfo">
                     <div class="pname">Eclipse JKube</div>
@@ -303,10 +306,10 @@
               </div>
 
               <div class="handles-row">
-                <div class="h" title="GitHub"><span class="k"><i class="fa-brands fa-github"></i></span><span class="v"><span class="at">@</span>manusa</span></div>
-                <div class="h" title="Bluesky"><span class="k"><i class="fa-brands fa-bluesky"></i></span><span class="v"><span class="at">@</span>marcnuri.com</span></div>
-                <div class="h" title="X (Twitter)"><span class="k"><i class="fa-brands fa-x-twitter"></i></span><span class="v"><span class="at">@</span>MarcNuri</span></div>
-                <div class="h" title="LinkedIn"><span class="k"><i class="fa-brands fa-linkedin-in"></i></span><span class="v">/in/marcnuri</span></div>
+                <div class="h" title="GitHub"><a class="ref-link overlay" href="https://github.com/manusa" target="_blank" rel="noopener noreferrer" aria-label="GitHub @manusa"></a><span class="k"><i class="fa-brands fa-github"></i></span><span class="v"><span class="at">@</span>manusa</span></div>
+                <div class="h" title="Bluesky"><a class="ref-link overlay" href="https://bsky.app/profile/marcnuri.com" target="_blank" rel="noopener noreferrer" aria-label="Bluesky @marcnuri.com"></a><span class="k"><i class="fa-brands fa-bluesky"></i></span><span class="v"><span class="at">@</span>marcnuri.com</span></div>
+                <div class="h" title="X (Twitter)"><a class="ref-link overlay" href="https://x.com/MarcNuri" target="_blank" rel="noopener noreferrer" aria-label="X (Twitter) @MarcNuri"></a><span class="k"><i class="fa-brands fa-x-twitter"></i></span><span class="v"><span class="at">@</span>MarcNuri</span></div>
+                <div class="h" title="LinkedIn"><a class="ref-link overlay" href="https://www.linkedin.com/in/marcnuri" target="_blank" rel="noopener noreferrer" aria-label="LinkedIn /in/marcnuri"></a><span class="k"><i class="fa-brands fa-linkedin-in"></i></span><span class="v">/in/marcnuri</span></div>
               </div>
             </div>
           </div>
@@ -356,6 +359,7 @@
               <div class="proj-grid">
 
           <div class="proj-card compact">
+            <a class="ref-link overlay" href="https://github.com/manusa/helm-java" target="_blank" rel="noopener noreferrer" aria-label="helm-java on GitHub"></a>
             <image-slot id="logo-helm-java" class="picon" fit="contain" src="assets/logos/helm.svg" placeholder="logo"></image-slot>
             <div class="pinfo">
               <div class="pname">helm-java</div>
@@ -368,6 +372,7 @@
           </div>
 
           <div class="proj-card compact">
+            <a class="ref-link overlay" href="https://github.com/manusa/actions-setup-minikube" target="_blank" rel="noopener noreferrer" aria-label="actions-setup-minikube on GitHub"></a>
             <image-slot id="logo-minikube" class="picon" fit="contain" src="assets/logos/minikube.svg" placeholder="logo"></image-slot>
             <div class="pinfo">
               <div class="pname">actions-setup-minikube</div>
@@ -380,6 +385,7 @@
           </div>
 
           <div class="proj-card compact">
+            <a class="ref-link overlay" href="https://github.com/manusa/ai-beacon" target="_blank" rel="noopener noreferrer" aria-label="ai-beacon on GitHub"></a>
             <image-slot id="logo-ai-beacon" class="picon" fit="contain" src="assets/logos/go.svg" placeholder="logo"></image-slot>
             <div class="pinfo">
               <div class="pname">ai-beacon</div>
@@ -392,6 +398,7 @@
           </div>
 
           <div class="proj-card compact">
+            <a class="ref-link overlay" href="https://github.com/manusa/electronim" target="_blank" rel="noopener noreferrer" aria-label="electronim on GitHub"></a>
             <image-slot id="logo-electronim" class="picon" fit="contain" src="assets/logos/electronim.svg" placeholder="logo"></image-slot>
             <div class="pinfo">
               <div class="pname">electronim</div>
@@ -404,6 +411,7 @@
           </div>
 
           <div class="proj-card compact">
+            <a class="ref-link overlay" href="https://github.com/manusa/yakd" target="_blank" rel="noopener noreferrer" aria-label="YAKD on GitHub"></a>
             <image-slot id="logo-yakd" class="picon" fit="contain" src="assets/logos/yakd-square.svg" placeholder="logo"></image-slot>
             <div class="pinfo">
               <div class="pname">YAKD</div>
@@ -416,6 +424,7 @@
           </div>
 
           <div class="proj-card compact">
+            <a class="ref-link overlay" href="https://github.com/manusa/podman-mcp-server" target="_blank" rel="noopener noreferrer" aria-label="podman-mcp-server on GitHub"></a>
             <image-slot id="logo-podman-mcp" class="picon" fit="contain" src="assets/logos/containers.png" placeholder="logo"></image-slot>
             <div class="pinfo">
               <div class="pname">podman-mcp-server</div>
@@ -428,6 +437,7 @@
           </div>
 
           <div class="proj-card compact book">
+            <a class="ref-link overlay" href="https://marcnuri.com/book" target="_blank" rel="noopener noreferrer" aria-label="Full Stack Quarkus and React (book)"></a>
             <image-slot id="book-cover"
                         class="book-slot"
                         shape="rounded"
@@ -441,6 +451,7 @@
           </div>
 
                 <div class="proj-card compact blog-card" style="grid-column: span 2;">
+                  <a class="ref-link overlay" href="https://blog.marcnuri.com" target="_blank" rel="noopener noreferrer" aria-label="blog.marcnuri.com"></a>
                   <div class="blog-tile">
                     <span class="logo-wordmark"><span class="seg-blog">blog.</span><span class="seg-marc">marc</span><span class="seg-nuri">nuri</span><span class="seg-com">.com</span></span>
                     <span class="blog-cap">// posts on Java, Kubernetes &amp; dev tools</span>
@@ -507,6 +518,7 @@
       <div class="collage" aria-hidden="true">
         <!-- Four pinned repo cards — every project named here is referenced in the talk -->
         <div class="card repo repo-1">
+          <a class="ref-link overlay" href="https://github.com/eclipse-jkube/jkube" target="_blank" rel="noopener noreferrer" aria-label="eclipse-jkube/jkube on GitHub"></a>
           <div class="repo-head">
             <span class="repo-icon">J</span>
             <div>
@@ -522,6 +534,7 @@
         </div>
 
         <div class="card repo repo-2">
+          <a class="ref-link overlay" href="https://github.com/containers/kubernetes-mcp-server" target="_blank" rel="noopener noreferrer" aria-label="containers/kubernetes-mcp-server on GitHub"></a>
           <div class="repo-head">
             <span class="repo-icon">G</span>
             <div>
@@ -536,6 +549,7 @@
         </div>
 
         <div class="card repo repo-3">
+          <a class="ref-link overlay" href="https://github.com/fabric8io/kubernetes-client" target="_blank" rel="noopener noreferrer" aria-label="fabric8io/kubernetes-client on GitHub"></a>
           <div class="repo-head">
             <span class="repo-icon">J</span>
             <div>
@@ -551,6 +565,7 @@
         </div>
 
         <div class="card repo repo-4">
+          <a class="ref-link overlay" href="https://github.com/manusa/helm-java" target="_blank" rel="noopener noreferrer" aria-label="manusa/helm-java on GitHub"></a>
           <div class="repo-head">
             <span class="repo-icon">J</span>
             <div>
@@ -1679,7 +1694,7 @@
         <article class="agents-panel">
           <header class="panel-bar">
             <span class="dot r"></span><span class="dot y"></span><span class="dot g"></span>
-            <span class="path">AGENTS.md  ·  fabric8 / kubernetes-client</span>
+            <a class="ref-link" href="https://github.com/fabric8io/kubernetes-client/blob/main/AGENTS.md" target="_blank" rel="noopener noreferrer"><span class="path">AGENTS.md  ·  fabric8 / kubernetes-client</span></a>
           </header>
           <div class="panel-body">
             <div class="ln md-h"># Build &amp; validation</div>
@@ -1829,7 +1844,7 @@ tasks.<span class="t-fn">register</span>(<span class="t-str">"quickBuild"</span>
             <span class="gh-icon"><i class="fa-brands fa-github"></i></span>
             <span class="repo">fabric8io / kubernetes-client</span>
             <span class="sep">·</span>
-            <span class="prnum">#7528</span>
+            <a class="ref-link" href="https://github.com/fabric8io/kubernetes-client/pull/7528" target="_blank" rel="noopener noreferrer"><span class="prnum">#7528</span></a>
             <span class="grow"></span>
             <span class="status open">Open</span>
           </header>
@@ -1908,7 +1923,7 @@ tasks.<span class="t-fn">register</span>(<span class="t-str">"quickBuild"</span>
             <span class="gh-icon"><i class="fa-brands fa-github"></i></span>
             <span class="repo">fabric8io / kubernetes-client</span>
             <span class="sep">·</span>
-            <span class="prnum">#7544</span>
+            <a class="ref-link" href="https://github.com/fabric8io/kubernetes-client/pull/7544" target="_blank" rel="noopener noreferrer"><span class="prnum">#7544</span></a>
             <span class="grow"></span>
             <span class="status merged">Merged</span>
           </header>
@@ -1925,7 +1940,7 @@ tasks.<span class="t-fn">register</span>(<span class="t-str">"quickBuild"</span>
               <div class="row"><span class="g">+</span><span class="k">Java models moved</span><span class="v">· <code>clusterapi.v1beta1</code> → <code>clusterapi.core.v1beta1</code></span></div>
             </div>
             <footer class="pr-foot">
-              <span class="closes">Closes <span class="num">#7528</span></span>
+              <span class="closes">Closes <a class="ref-link" href="https://github.com/fabric8io/kubernetes-client/pull/7528" target="_blank" rel="noopener noreferrer"><span class="num">#7528</span></a></span>
               <span class="meta">32 files · 3 cascade bumps · <strong>was open 5 days</strong></span>
               <span class="async">// ran while I slept.</span>
             </footer>
@@ -2737,7 +2752,7 @@ tasks.<span class="t-fn">register</span>(<span class="t-str">"quickBuild"</span>
         <article class="card card-speed">
           <header class="panel-bar term">
             <span class="dot r"></span><span class="dot y"></span><span class="dot g"></span>
-            <span class="path">fabric8io/kubernetes-client · windows-build</span>
+            <a class="ref-link" href="https://github.com/fabric8io/kubernetes-client/actions/workflows/windows-build.yml" target="_blank" rel="noopener noreferrer"><span class="path">fabric8io/kubernetes-client · windows-build</span></a>
             <span class="grow"></span>
             <span class="status-pill st-stable">✓ stable</span>
           </header>
@@ -2759,7 +2774,7 @@ tasks.<span class="t-fn">register</span>(<span class="t-str">"quickBuild"</span>
             </div>
             <div class="hero-byline">
               <span class="lbl">windows build</span>
-              <span class="dim"> · 40m flaky (run #22430057522) → ~22m stable (current main)</span>
+              <span class="dim"> · 40m flaky (<a class="ref-link" href="https://github.com/fabric8io/kubernetes-client/actions/runs/22430057522" target="_blank" rel="noopener noreferrer">run #22430057522</a>) → ~22m stable (current main)</span>
             </div>
 
             <div class="modules">
@@ -2860,7 +2875,7 @@ tasks.<span class="t-fn">register</span>(<span class="t-str">"quickBuild"</span>
             <span class="gh-icon"><i class="fa-brands fa-github"></i></span>
             <span class="repo">fabric8io / kubernetes-client</span>
             <span class="sep">·</span>
-            <span class="path">issues?q=is:closed+label:flaky</span>
+            <a class="ref-link" href="https://github.com/fabric8io/kubernetes-client/issues?q=is%3Aclosed+label%3Aflaky" target="_blank" rel="noopener noreferrer"><span class="path">issues?q=is:closed+label:flaky</span></a>
             <span class="grow"></span>
             <span class="gh-pill flaky">label: flaky</span>
           </header>
@@ -2879,7 +2894,7 @@ tasks.<span class="t-fn">register</span>(<span class="t-str">"quickBuild"</span>
                 <div class="body">
                   <div class="title-row">
                     <span class="title"><span class="ident">ExecWebSocketListener.onError</span> drops exit code on peer-close race</span>
-                    <span class="num">#7700</span>
+                    <a class="ref-link" href="https://github.com/fabric8io/kubernetes-client/issues/7700" target="_blank" rel="noopener noreferrer"><span class="num">#7700</span></a>
                   </div>
                   <div class="labels">
                     <span class="lbl flaky">flaky</span>
@@ -2900,14 +2915,14 @@ tasks.<span class="t-fn">register</span>(<span class="t-str">"quickBuild"</span>
                 <div class="body">
                   <div class="title-row">
                     <span class="title"><span class="ident">ExecListener.onClose / onFailure</span> lost on close-handshake race</span>
-                    <span class="num">#7779</span>
+                    <a class="ref-link" href="https://github.com/fabric8io/kubernetes-client/issues/7779" target="_blank" rel="noopener noreferrer"><span class="num">#7779</span></a>
                   </div>
                   <div class="labels">
                     <span class="lbl flaky">flaky</span>
                     <span class="lbl realbug">production bug</span>
                   </div>
                   <p class="cause">
-                    Surfaced via flake <span class="ident">#7756</span>.
+                    Surfaced via flake <a class="ref-link" href="https://github.com/fabric8io/kubernetes-client/issues/7756" target="_blank" rel="noopener noreferrer"><span class="ident">#7756</span></a>.
                     Any production transport that drops the close handshake under load
                     left callers blocked on a latch <em>forever</em>.
                   </p>
@@ -2920,7 +2935,7 @@ tasks.<span class="t-fn">register</span>(<span class="t-str">"quickBuild"</span>
                 <div class="body">
                   <div class="title-row">
                     <span class="title"><span class="ident">SharedProcessor.distribute()</span> NPEs if called after <span class="ident">informer.stop()</span></span>
-                    <span class="num">#7716</span>
+                    <a class="ref-link" href="https://github.com/fabric8io/kubernetes-client/issues/7716" target="_blank" rel="noopener noreferrer"><span class="num">#7716</span></a>
                   </div>
                   <div class="labels">
                     <span class="lbl flaky">flaky</span>
@@ -3087,19 +3102,19 @@ tasks.<span class="t-fn">register</span>(<span class="t-str">"quickBuild"</span>
         <div class="contact-block">
           <span class="clabel">// keep in touch</span>
           <div class="contact-list">
-            <div class="row" title="GitHub"><span class="k"><i class="fa-brands fa-github"></i></span><span class="v"><span class="at">@</span>manusa</span></div>
-            <div class="row" title="Bluesky"><span class="k"><i class="fa-brands fa-bluesky"></i></span><span class="v"><span class="at">@</span>marcnuri.com</span></div>
-            <div class="row" title="X (Twitter)"><span class="k"><i class="fa-brands fa-x-twitter"></i></span><span class="v"><span class="at">@</span>MarcNuri</span></div>
-            <div class="row" title="LinkedIn"><span class="k"><i class="fa-brands fa-linkedin-in"></i></span><span class="v">/in/marcnuri</span></div>
-            <div class="row" title="Blog"><span class="k"><i class="fa-solid fa-rss"></i></span><span class="v">blog.marcnuri.com</span></div>
-            <div class="row" title="YouTube"><span class="k"><i class="fa-brands fa-youtube"></i></span><span class="v">/MarcNuri</span></div>
-            <div class="row" title="Website"><span class="k"><i class="fa-solid fa-globe"></i></span><span class="v">marcnuri.com</span></div>
+            <div class="row" title="GitHub"><a class="ref-link overlay" href="https://github.com/manusa" target="_blank" rel="noopener noreferrer" aria-label="GitHub @manusa"></a><span class="k"><i class="fa-brands fa-github"></i></span><span class="v"><span class="at">@</span>manusa</span></div>
+            <div class="row" title="Bluesky"><a class="ref-link overlay" href="https://bsky.app/profile/marcnuri.com" target="_blank" rel="noopener noreferrer" aria-label="Bluesky @marcnuri.com"></a><span class="k"><i class="fa-brands fa-bluesky"></i></span><span class="v"><span class="at">@</span>marcnuri.com</span></div>
+            <div class="row" title="X (Twitter)"><a class="ref-link overlay" href="https://x.com/MarcNuri" target="_blank" rel="noopener noreferrer" aria-label="X (Twitter) @MarcNuri"></a><span class="k"><i class="fa-brands fa-x-twitter"></i></span><span class="v"><span class="at">@</span>MarcNuri</span></div>
+            <div class="row" title="LinkedIn"><a class="ref-link overlay" href="https://www.linkedin.com/in/marcnuri" target="_blank" rel="noopener noreferrer" aria-label="LinkedIn /in/marcnuri"></a><span class="k"><i class="fa-brands fa-linkedin-in"></i></span><span class="v">/in/marcnuri</span></div>
+            <div class="row" title="Blog"><a class="ref-link overlay" href="https://blog.marcnuri.com" target="_blank" rel="noopener noreferrer" aria-label="blog.marcnuri.com"></a><span class="k"><i class="fa-solid fa-rss"></i></span><span class="v">blog.marcnuri.com</span></div>
+            <div class="row" title="YouTube"><a class="ref-link overlay" href="https://www.youtube.com/@MarcNuri" target="_blank" rel="noopener noreferrer" aria-label="YouTube /MarcNuri"></a><span class="k"><i class="fa-brands fa-youtube"></i></span><span class="v">/MarcNuri</span></div>
+            <div class="row" title="Website"><a class="ref-link overlay" href="https://marcnuri.com" target="_blank" rel="noopener noreferrer" aria-label="marcnuri.com"></a><span class="k"><i class="fa-solid fa-globe"></i></span><span class="v">marcnuri.com</span></div>
           </div>
         </div>
 
         <div class="qr-wrap">
           <div class="qr"></div>
-          <div class="qr-label">→ slides &amp; links · blog.marcnuri.com</div>
+          <div class="qr-label">→ slides &amp; links · <a class="ref-link" href="https://blog.marcnuri.com" target="_blank" rel="noopener noreferrer">blog.marcnuri.com</a></div>
         </div>
       </div>
     </div>

--- a/static/presentations/2026-devtalks-romania/styles/s-about2.css
+++ b/static/presentations/2026-devtalks-romania/styles/s-about2.css
@@ -334,6 +334,14 @@
   transform: rotateY(180deg);
 }
 
+/* backface-visibility:hidden hides the back face from view, but its
+   descendants (interactive elements such as our overlay anchors) default to
+   backface-visibility:visible and remain hit-testable from behind. Drop
+   pointer-events on the non-visible face per step so a click on the empty
+   area of the visible face never activates a link on the hidden one. */
+.s-about2-flip[data-step="0"] .face-back  { pointer-events: none; }
+.s-about2-flip[data-step="1"] .face-front { pointer-events: none; }
+
 /* Print / PDF: collapse the 3D so each face is captured as a flat
    page. export:pdf renders this slide at data-step="0" then
    data-step="1"; we hide the off-step face on each. */

--- a/static/presentations/2026-devtalks-romania/styles/s-ci.css
+++ b/static/presentations/2026-devtalks-romania/styles/s-ci.css
@@ -142,21 +142,21 @@
    Step 0 hides all three. */
 
 /* widths */
-.s-ci .card-speed { width: calc((100% - 30px) / 2); left: calc(25% + 7.5px); opacity: 0; }
-.s-ci .card-cost  { width: calc((100% - 30px) / 2); left: 110%;                opacity: 0; }
-.s-ci .card-bugs  { width: 100%;                    left: 110%;                opacity: 0; }
+.s-ci .card-speed { width: calc((100% - 30px) / 2); left: calc(25% + 7.5px); opacity: 0; pointer-events: none; }
+.s-ci .card-cost  { width: calc((100% - 30px) / 2); left: 110%;                opacity: 0; pointer-events: none; }
+.s-ci .card-bugs  { width: 100%;                    left: 110%;                opacity: 0; pointer-events: none; }
 
 /* step 1 — speed reveal in LEFT slot (centered alone) */
-.s-ci[data-step="1"] .card-speed { left: calc(25% + 7.5px); opacity: 1; }
+.s-ci[data-step="1"] .card-speed { left: calc(25% + 7.5px); opacity: 1; pointer-events: auto; }
 
 /* step 2 — speed shifts to true LEFT; cost enters RIGHT */
-.s-ci[data-step="2"] .card-speed { left: 0;                  opacity: 1; }
-.s-ci[data-step="2"] .card-cost  { left: calc(50% + 15px);   opacity: 1; }
+.s-ci[data-step="2"] .card-speed { left: 0;                  opacity: 1; pointer-events: auto; }
+.s-ci[data-step="2"] .card-cost  { left: calc(50% + 15px);   opacity: 1; pointer-events: auto; }
 
 /* step 3 — speed + cost slide off left; bugs takes full width */
-.s-ci[data-step="3"] .card-speed { left: -55%;               opacity: 0; }
-.s-ci[data-step="3"] .card-cost  { left: -55%;               opacity: 0; }
-.s-ci[data-step="3"] .card-bugs  { left: 0;                  opacity: 1; }
+.s-ci[data-step="3"] .card-speed { left: -55%;               opacity: 0; pointer-events: none; }
+.s-ci[data-step="3"] .card-cost  { left: -55%;               opacity: 0; pointer-events: none; }
+.s-ci[data-step="3"] .card-bugs  { left: 0;                  opacity: 1; pointer-events: auto; }
 
 /* ============================================================
    Step 0 INTRO — a small centered framing block ("case study

--- a/static/presentations/2026-devtalks-romania/styles/shared.css
+++ b/static/presentations/2026-devtalks-romania/styles/shared.css
@@ -139,6 +139,48 @@ deck-stage section {
 .chrome-bottom .spacer { flex: 1; }
 .chrome-bottom .sep { color: var(--fg-mute); opacity: 0.5; }
 
+/* Invisible reference link: native pointer on hover, nothing else.
+   Two usage patterns:
+   (1) Inline text wrap — <span><a class="ref-link">…</a></span> for PR/issue
+       numbers, panel-bar paths, etc. The anchor inherits inline flow.
+   (2) Overlay click target — <div class="card"><a class="ref-link"></a>…</div>
+       on cards / rows / handles. The anchor is positioned absolutely over the
+       container so it has a finite rect (required for Chromium page.pdf() to
+       emit a PDF link annotation) without disturbing layout. The container
+       gets position:relative locally next to where the overlay is declared. */
+.ref-link,
+.ref-link:link,
+.ref-link:visited,
+.ref-link:hover,
+.ref-link:active {
+  color: inherit;
+  text-decoration: none;
+  background: transparent;
+}
+/* Suppress the mouse-focus halo (which would otherwise persist after clicking
+   a link and bleed into snapshot captures) without removing keyboard focus
+   visibility — :focus-visible only fires for keyboard-initiated focus. */
+.ref-link:focus { outline: none; }
+.ref-link:focus-visible {
+  outline: 2px solid currentColor;
+  outline-offset: 2px;
+  border-radius: 2px;
+}
+.ref-link.overlay {
+  position: absolute;
+  inset: 0;
+  z-index: 5;
+}
+/* Scoped to the host containers that actually need a positioning context
+   added — keeps the rule from accidentally re-positioning unrelated DOM.
+   Not listed because they already have their own:
+     .proj-card                — already position:relative
+     .s-fieldnotes .card.repo  — position:absolute (also a positioning ctx) */
+.s-about2 .handles-row .h:has(> .ref-link.overlay),
+.s-closing .contact-list .row:has(> .ref-link.overlay) {
+  position: relative;
+}
+
 /* Common slide body */
 .slide-body {
   position: absolute;


### PR DESCRIPTION
## Summary

- Wrap ~38 real references in the 2026 DevTalks Romania deck — GitHub repo cards (slides 02 / 03), PR & issue numbers (slides 14 / 22), panel-bar paths (slides 11 / 22), and social handles (slides 02 / 17) — in `<a target="_blank" rel="noopener noreferrer">`.
- Two anchor patterns inside one tiny `.ref-link` utility in `styles/shared.css`:
  - **Inline** for PR/issue numbers and panel-bar text.
  - **Absolute-overlay** empty anchors for cards / contact rows / handle items — required for Chromium's `page.pdf()` to emit real PDF link annotations.
- Visual stays identical: color / text-decoration / background / focus all neutralized; native pointer cursor is the only hover signal.

## Verification

- **`snapshot:diff`** against pre-edit baseline: 36 of 38 captures pixel-identical. Two captures (`s-ci` speed card, dark terminal panel) show 41 + 34 pixels (0.002% each) — sub-pixel rasterizer noise at inline-anchor element boundaries on dark backgrounds, below human perception and an unavoidable artifact of wrapping inline text in `<a>`.
- **PDF (`npm run export:pdf`)**: 42 URI annotations across 27 unique URLs — every reference in the issue's inventory is present and clickable in Preview / browser PDF viewers.
- **AGENTS.md upstream path** verified live (still at `fabric8io/kubernetes-client/blob/main/AGENTS.md`).
- **Do-not-link** sanity: `ISSUE-1337`, `Tests PR #37`, `agent.log — ci · pull-request #4271`, every `chrome-top` / `chrome-bottom` decoration, slide-19 / 21 chips — all unchanged.

## Test plan

- [ ] Walk through the served deck and click a sample anchor on each touched slide (02 / 03 / 11 / 14 / 17 / 22) — verify each opens the right URL in a new tab.
- [ ] Open the exported PDF in Preview / Acrobat and click 4-5 sample links across the same slides — verify they navigate.
- [ ] Keyboard nav (ArrowLeft / ArrowRight, `#N` hash deep-link) still advances slides and steps after the change.
- [ ] Eyeball the `s-ci` speed card byline `(run #22430057522)` side-by-side with baseline — confirm the 0.002% pixel diff is visually imperceptible.

Fixes manusa/com.marcnuri.automated-tasks#1823