### PR TITLE
✨ devtalks-2026: add slides 23 (XP reframe) + 24 (recap)

### DIFF
--- a/static/presentations/2026-devtalks-romania/index.html
+++ b/static/presentations/2026-devtalks-romania/index.html
@@ -31,6 +31,8 @@
 <link rel="stylesheet" href="styles/s-project-story.css" />
 <link rel="stylesheet" href="styles/s-feedback-ladder.css" />
 <link rel="stylesheet" href="styles/s-ci.css" />
+<link rel="stylesheet" href="styles/s-xp-reframe.css" />
+<link rel="stylesheet" href="styles/s-recap.css" />
 </head>
 <body>
 
@@ -3334,6 +3336,55 @@ tasks.<span class="t-fn">register</span>(<span class="t-str">"quickBuild"</span>
   </section>
 
   <!-- ============================================================
+       23 XP REFRAME — Act V close ("Did I just advertise XP?").
+       Single static reveal: the audience has been listening to
+       XP for 30 minutes. Visual emptiness is deliberate.
+       ============================================================ -->
+  <section class="s-xp-reframe light" data-label="Act 5 — Did I just advertise XP?">
+    <div class="chrome-top">
+      <span class="dot"></span>
+      <span>~/dev/devtalks-2026 · devtalks-act-05-codebase-feedback/Reframe.java</span>
+      <span class="spacer"></span>
+      <span class="pill">act 05 · the reframe · 23</span>
+    </div>
+
+    <div class="body">
+      <header class="head">
+        <h2 class="title">Did I just advertise <em>XP</em>?</h2>
+      </header>
+
+      <div class="reveal">
+        <div class="reveal-stamp">
+          <span class="stamp-title">Extreme Programming</span>
+          <span class="stamp-rule"></span>
+          <span class="stamp-sub">est. 1999</span>
+        </div>
+
+        <span class="reveal-arrow" aria-hidden="true">→</span>
+
+        <ul class="practices">
+          <li>TDD</li>
+          <li>small steps</li>
+          <li>continuous integration</li>
+          <li>shared knowledge</li>
+          <li>simple design</li>
+        </ul>
+      </div>
+
+      <div class="reveal-closers">
+        <p class="reveal-line">Discipline. <em>Just renamed.</em></p>
+        <p class="reveal-line reveal-line-sub">AI just made the cost of <em>skipping it</em> obvious.</p>
+      </div>
+    </div>
+
+    <div class="chrome-bottom">
+      <div class="left"><span class="brand-mark">marc nuri</span><span class="sep">|</span><span>red hat</span></div>
+      <span class="spacer"></span>
+      <div class="right"><span>devtalks.ro · 2026</span></div>
+    </div>
+  </section>
+
+  <!-- ============================================================
        ACT VI DIVIDER — CLOSE (Maven reactor)
        ============================================================ -->
   <section class="s-section" data-label="Act VI — Close">
@@ -3422,6 +3473,78 @@ tasks.<span class="t-fn">register</span>(<span class="t-str">"quickBuild"</span>
           <span class="state">BUILDING</span>
           <span class="dur">...</span>
         </div>
+      </div>
+    </div>
+
+    <div class="chrome-bottom">
+      <div class="left"><span class="brand-mark">marc nuri</span><span class="sep">|</span><span>red hat</span></div>
+      <span class="spacer"></span>
+      <div class="right"><span>devtalks.ro · 2026</span></div>
+    </div>
+  </section>
+
+  <!-- ============================================================
+       24 RECAP — Act VI: Map · Roads · Guardrails + this-week
+       checklist + bookend quote. Single static state.
+       ============================================================ -->
+  <section class="s-recap light" data-label="Act 6 — Recap: Map · Roads · Guardrails">
+    <div class="chrome-top">
+      <span class="dot"></span>
+      <span>~/dev/devtalks-2026 · devtalks-act-06-close/Recap.java</span>
+      <span class="spacer"></span>
+      <span class="pill">act 06 · recap · 24</span>
+    </div>
+
+    <div class="body">
+      <header class="head">
+        <div class="eyebrow">// act 06 · recap</div>
+        <h2 class="title">
+          <span class="w-map">Map</span><span class="sep">·</span><span class="w-roads">Roads</span><span class="sep">·</span><span class="w-guard">Guardrails</span>.
+        </h2>
+      </header>
+
+      <div class="pillars">
+        <article class="pillar pillar-map">
+          <h3 class="pillar-name">Map</h3>
+          <div class="pillar-action">
+            <span class="pillar-action-lbl">// this week</span>
+            <ul class="pillar-action-list">
+              <li><code>git add AGENTS.md</code></li>
+              <li>Document one thing every maintainer knows</li>
+            </ul>
+          </div>
+          <i class="pillar-icon fa-solid fa-map" aria-hidden="true"></i>
+        </article>
+
+        <article class="pillar pillar-roads">
+          <h3 class="pillar-name">Roads</h3>
+          <div class="pillar-action">
+            <span class="pillar-action-lbl">// this week</span>
+            <ul class="pillar-action-list">
+              <li>Turn one maintainer routine into a <code>SKILL.md</code></li>
+            </ul>
+          </div>
+          <i class="pillar-icon fa-solid fa-road" aria-hidden="true"></i>
+        </article>
+
+        <article class="pillar pillar-guardrails">
+          <h3 class="pillar-name">Guardrails</h3>
+          <div class="pillar-action">
+            <span class="pillar-action-lbl">// this week</span>
+            <ul class="pillar-action-list">
+              <li>Fix one flaky test for real</li>
+              <li>Turn one bug report into a failing test</li>
+            </ul>
+          </div>
+          <i class="pillar-icon fa-solid fa-shield-halved" aria-hidden="true"></i>
+        </article>
+      </div>
+
+      <div class="closer">
+        <p class="closer-quote">
+          AI takes the repetitive grind.<br>
+          <em>You keep the judgment.</em>
+        </p>
       </div>
     </div>
 

--- a/static/presentations/2026-devtalks-romania/styles/s-recap.css
+++ b/static/presentations/2026-devtalks-romania/styles/s-recap.css
@@ -1,0 +1,158 @@
+/* ============================================================
+   S-RECAP — Act VI recap (Map · Roads · Guardrails).
+   Single static state. Three pillars · one action each ·
+   bookend quote. Uses deck type tokens; minimum body 24px.
+   ============================================================ */
+.s-recap .body {
+  padding: 84px var(--pad-x) 64px;
+  display: grid;
+  grid-template-rows: auto 1fr auto;
+  row-gap: 56px;
+}
+
+/* ---------- Header ---------- */
+.s-recap .head {
+  display: grid;
+  row-gap: 14px;
+}
+.s-recap .head .eyebrow {
+  font-size: var(--type-eyebrow);
+}
+.s-recap .head .title {
+  font-family: 'Inter', sans-serif;
+  font-size: var(--type-title);
+  font-weight: 800;
+  line-height: 1;
+  letter-spacing: -0.025em;
+  margin: 0;
+  color: var(--fg);
+}
+.s-recap .head .title .sep {
+  color: var(--line-strong);
+  margin: 0 18px;
+  font-weight: 400;
+}
+.s-recap .head .title .w-map   { color: var(--cyan-ink); }
+.s-recap .head .title .w-roads { color: var(--accent-2-ink); }
+.s-recap .head .title .w-guard { color: var(--accent-ink); }
+
+/* ---------- Pillars (three columns) ---------- */
+.s-recap .pillars {
+  display: grid;
+  grid-template-columns: 1fr 1fr 1fr;
+  column-gap: 32px;
+  align-content: start;
+}
+.s-recap .pillar {
+  position: relative;
+  overflow: hidden;
+  background: var(--bg-card);
+  border: 1px solid var(--line);
+  border-radius: 16px;
+  padding: 32px 36px 36px;
+  display: grid;
+  grid-template-rows: 60px 32px auto;
+  box-shadow: 0 2px 14px rgba(10, 21, 84, 0.05);
+  min-height: 320px;
+}
+.s-recap .pillar-map        { --pillar-color: var(--cyan-ink); }
+.s-recap .pillar-roads      { --pillar-color: var(--accent-2-ink); }
+.s-recap .pillar-guardrails { --pillar-color: var(--accent-ink); }
+
+.s-recap .pillar-name {
+  font-family: 'Inter', sans-serif;
+  font-size: var(--type-h2);
+  font-weight: 800;
+  letter-spacing: -0.022em;
+  color: var(--pillar-color);
+  line-height: 1;
+  margin: 0;
+  grid-row: 1;
+  align-self: start;
+  display: block;
+  white-space: nowrap;
+}
+
+.s-recap .pillar-action {
+  display: grid;
+  row-gap: 10px;
+  align-self: start;
+  grid-row: 3;
+  position: relative;
+  z-index: 1;
+}
+.s-recap .pillar-action-lbl {
+  font-family: 'JetBrains Mono', monospace;
+  font-size: var(--type-small);
+  letter-spacing: 0.04em;
+  color: var(--pillar-color);
+  opacity: 0.85;
+}
+.s-recap .pillar-action-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  row-gap: 12px;
+}
+.s-recap .pillar-action-list li {
+  font-family: 'JetBrains Mono', monospace;
+  font-size: var(--type-mono);
+  line-height: 1.32;
+  color: var(--fg);
+  position: relative;
+  padding-left: 26px;
+}
+.s-recap .pillar-action-list li::before {
+  content: "▸";
+  position: absolute;
+  left: 0;
+  top: 0;
+  color: var(--pillar-color);
+  font-weight: 700;
+}
+.s-recap .pillar-action-list li code {
+  background: rgba(10, 21, 84, 0.06);
+  color: var(--fg);
+  padding: 2px 10px;
+  border-radius: 6px;
+  font-weight: 600;
+}
+
+/* Icon watermark — large, low opacity, bottom-right of card. */
+.s-recap .pillar-icon {
+  position: absolute;
+  right: -12px;
+  bottom: -18px;
+  font-size: 168px;
+  line-height: 1;
+  color: var(--pillar-color);
+  opacity: 0.12;
+  pointer-events: none;
+  z-index: 0;
+}
+
+/* ---------- Closing line ---------- */
+.s-recap .closer {
+  display: grid;
+  row-gap: 4px;
+  align-self: end;
+}
+.s-recap .closer-quote {
+  font-family: 'Inter', sans-serif;
+  font-size: var(--type-h2);
+  font-weight: 800;
+  letter-spacing: -0.018em;
+  line-height: 1.12;
+  margin: 0;
+  color: var(--fg);
+}
+.s-recap .closer-quote em {
+  font-style: normal;
+  color: var(--accent-ink);
+}
+
+/* ---------- Print ---------- */
+@media print {
+  .s-recap .pillar { box-shadow: none; }
+}

--- a/static/presentations/2026-devtalks-romania/styles/s-xp-reframe.css
+++ b/static/presentations/2026-devtalks-romania/styles/s-xp-reframe.css
@@ -1,0 +1,145 @@
+/* ============================================================
+   S-XP-REFRAME — Act V close ("Did I just advertise XP?").
+   Three-row vertical rhythm: headline · reveal (stamp →
+   bullets) · two-line closer. The visual carries the
+   recognition; the headline carries the rhetorical question.
+   ============================================================ */
+.s-xp-reframe .body {
+  position: absolute;
+  inset: 56px 0 56px 0;
+  padding: 96px var(--pad-x) 84px;
+  display: grid;
+  grid-template-rows: auto 1fr auto;
+  row-gap: 48px;
+}
+
+/* ---------- Headline (top) ---------- */
+.s-xp-reframe .head {
+  display: grid;
+  row-gap: 14px;
+}
+.s-xp-reframe .head .title {
+  font-family: 'Inter', sans-serif;
+  font-size: 96px;
+  font-weight: 800;
+  line-height: 1;
+  letter-spacing: -0.028em;
+  color: var(--fg);
+  margin: 0;
+}
+.s-xp-reframe .head .title em {
+  font-style: normal;
+  color: var(--accent-ink);
+}
+
+/* ---------- Reveal — three-column composition ---------- */
+.s-xp-reframe .reveal {
+  display: grid;
+  grid-template-columns: auto auto 1fr;
+  column-gap: 64px;
+  align-items: center;
+  justify-content: start;
+  align-self: center;
+}
+
+/* ---------- Left column — the stamp ---------- */
+.s-xp-reframe .reveal-stamp {
+  position: relative;
+  border: 5px solid var(--accent-ink);
+  background: rgba(184, 23, 66, 0.04);
+  color: var(--accent-ink);
+  padding: 36px 56px 30px;
+  display: grid;
+  row-gap: 14px;
+  justify-items: center;
+  border-radius: 8px;
+  transform: rotate(-1.4deg);
+  box-shadow: 0 6px 20px rgba(184, 23, 66, 0.10);
+}
+.s-xp-reframe .stamp-title {
+  font-family: 'Inter', sans-serif;
+  font-size: 72px;
+  font-weight: 900;
+  line-height: 0.95;
+  letter-spacing: -0.025em;
+  white-space: nowrap;
+}
+.s-xp-reframe .stamp-rule {
+  width: 80%;
+  height: 3px;
+  background: var(--accent-ink);
+  opacity: 0.5;
+  border-radius: 1.5px;
+}
+.s-xp-reframe .stamp-sub {
+  font-family: 'JetBrains Mono', monospace;
+  font-size: var(--type-mono);
+  font-weight: 600;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+}
+
+/* ---------- Middle column — arrow ---------- */
+.s-xp-reframe .reveal-arrow {
+  font-family: 'Inter', sans-serif;
+  font-size: 96px;
+  font-weight: 800;
+  color: var(--accent-ink);
+  line-height: 1;
+  align-self: center;
+}
+
+/* ---------- Right column — the practices bullets ---------- */
+.s-xp-reframe .practices {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  row-gap: 14px;
+}
+.s-xp-reframe .practices li {
+  font-family: 'Inter', sans-serif;
+  font-size: var(--type-subtitle);
+  font-weight: 700;
+  color: var(--fg);
+  line-height: 1.05;
+  letter-spacing: -0.015em;
+  display: grid;
+  grid-template-columns: 36px auto;
+  align-items: baseline;
+  column-gap: 4px;
+}
+.s-xp-reframe .practices li::before {
+  content: "▸";
+  color: var(--accent-ink);
+  font-weight: 700;
+  text-align: left;
+}
+
+/* ---------- Closing block (bottom) ---------- */
+.s-xp-reframe .reveal-closers {
+  display: grid;
+  row-gap: 12px;
+}
+.s-xp-reframe .reveal-line {
+  font-family: 'Inter', sans-serif;
+  font-size: var(--type-h2);
+  font-weight: 800;
+  letter-spacing: -0.015em;
+  line-height: 1.1;
+  color: var(--fg);
+  margin: 0;
+}
+.s-xp-reframe .reveal-line em {
+  font-style: normal;
+  color: var(--accent-ink);
+}
+.s-xp-reframe .reveal-line-sub {
+  font-size: var(--type-subtitle);
+  font-weight: 600;
+  color: var(--fg-dim);
+}
+.s-xp-reframe .reveal-line-sub em {
+  color: var(--accent-ink);
+  font-weight: 800;
+}


### PR DESCRIPTION
## Summary

Two new content slides closing the talk arc:

- **Slide 23 — XP reframe** (`s-xp-reframe`): single-state visual reveal. A rotated "Extreme Programming · est. 1999" stamp + arrow pointing to the five XP practices Marc just taught (TDD, small steps, continuous integration, shared knowledge, simple design). Headline keeps the rhetorical question; the stamp + bullets carry the click. Closer: "Discipline. Just renamed. / AI just made the cost of skipping it obvious."
- **Slide 24 — Map · Roads · Guardrails recap** (`s-recap`): three pillar cards with color-coded headers (cyan/orange/pink), 2-1-2 "this week" actions per pillar, FA watermark icons (`fa-map`, `fa-road`, `fa-shield-halved`) at 168px low-opacity in the bottom-right, and the bookend quote "AI takes the repetitive grind. You keep the judgment."

## Design notes

- Both slides went through UX review for type hierarchy, family fit, and reveal speed.
- Deck type tokens honored throughout (`--type-display`, `--type-title`, `--type-h2`, `--type-mono`, `--type-small`) — no off-scale sizes.
- `position: absolute; inset: 56px 0` on the body so the `auto 1fr auto` grid row actually stretches — same pattern as `s-closing`.
- Slide 23's stamp is a pure HTML/CSS rotation (`transform: rotate(-1.4deg)`) with `--accent-ink` border + low-alpha fill. No image assets.
- Slide 24's pillar header row is pinned to a fixed 60px so `// this week` labels align across cards even with different word lengths (Map/Roads/Guardrails).

## Test plan

- [ ] `npm run serve:static`, step through slides 23–26 with arrow keys; verify chrome pills (`act 05 · the reframe · 23`, `act 06 · recap · 24`) and layout
- [ ] `npm run snapshot:diff`: only the inserted slides + downstream shift should differ; all other slides identical
- [ ] `npm run export:pdf` and confirm stamp rotation + FA icons render in the PDF
- [ ] Project at 1920×1080 to confirm room-distance legibility for the pillar `// this week` labels and the XP closer lines