### PR TITLE
✨ devtalks-2026: add slides 12 (Java boundaries) + 13 (shape work upstream)

### DIFF
--- a/static/presentations/2026-devtalks-romania/index.html
+++ b/static/presentations/2026-devtalks-romania/index.html
@@ -24,6 +24,8 @@
 <link rel="stylesheet" href="styles/s-legacy.css" />
 <link rel="stylesheet" href="styles/s-flywheel.css" />
 <link rel="stylesheet" href="styles/s-agents-md.css" />
+<link rel="stylesheet" href="styles/s-boundaries.css" />
+<link rel="stylesheet" href="styles/s-leverage.css" />
 <link rel="stylesheet" href="styles/s-skill.css" />
 <link rel="stylesheet" href="styles/s-specs-vs-tests.css" />
 <link rel="stylesheet" href="styles/s-failure-spec.css" />
@@ -1789,6 +1791,256 @@ tasks.<span class="t-fn">register</span>(<span class="t-str">"quickBuild"</span>
         <div class="quotes">
           <span class="quote q-0">Not generic. <em>Project-specific.</em></span>
           <span class="quote q-1">Project-specific. <em>And executable.</em></span>
+        </div>
+      </div>
+    </div>
+
+    <div class="chrome-bottom">
+      <div class="left"><span class="brand-mark">marc nuri</span><span class="sep">|</span><span>red hat</span></div>
+      <span class="spacer"></span>
+      <div class="right"><span>devtalks.ro · 2026</span></div>
+    </div>
+  </section>
+
+  <!-- ============================================================
+       12 ACT 4 · MAKE JAVA BOUNDARIES OBVIOUS
+
+       The roads, after slide 11's map. Maven modules are reasoning
+       boundaries: a Vert.x change has an obvious home and a small
+       blast radius. Real proof — commit 68991cb8 (fabric8io/
+       kubernetes-client, 2026-05-18): 4 test files, both Vert.x
+       modules, 0 public-API files, 0 generated files.
+
+       Step 0 — structure: full module tree + commit card.
+       Step 1 — proof: non-Vert.x rows dim, the Vert.x row keeps a
+                pink marker, the reasoning-radius caption lands.
+       ============================================================ -->
+  <section class="s-boundaries light" data-label="Act 4 — Make Java boundaries obvious" data-step-max="1">
+    <div class="chrome-top">
+      <span class="dot"></span>
+      <span>~/dev/devtalks-2026 · fabric8io/kubernetes-client/pom.xml</span>
+      <span class="spacer"></span>
+      <span class="pill">act 04 · boundaries · 12</span>
+    </div>
+
+    <div class="body">
+      <header class="head">
+        <div class="eyebrow">// act 04 · boundaries</div>
+        <h2 class="title">Make Java boundaries <em>obvious</em>.</h2>
+        <p class="sub">
+          The agent shouldn't have to reason about the whole<br/>
+          repo to make a <em>local</em> change.
+        </p>
+      </header>
+
+      <div class="stage">
+        <!-- ============================================================
+             PROBLEM layer (step 0) — a HYPOTHETICAL monolith. One
+             module, one package, everything mixed: the structure tells
+             the agent nothing, so it reasons about the whole repo.
+             ============================================================ -->
+        <div class="layer layer-problem">
+          <article class="tree-panel synth">
+            <header class="panel-bar">
+              <span class="dot r"></span><span class="dot y"></span><span class="dot g"></span>
+              <span class="path">your-java-project</span>
+              <span class="grow"></span>
+              <span class="scope bad">no module boundaries</span>
+            </header>
+            <div class="tree">
+              <div class="tline">acme-platform/</div>
+              <div class="tline sub">└ src/main/java/com/acme/app/</div>
+              <div class="t"><span class="dot"></span><span class="mod">VertxConnector.java</span></div>
+              <div class="t"><span class="dot"></span><span class="mod">OkHttpConnector.java</span></div>
+              <div class="t"><span class="dot"></span><span class="mod">ClusterClient.java</span></div>
+              <div class="t"><span class="dot"></span><span class="mod">ModelTypes.java</span></div>
+              <div class="t"><span class="dot"></span><span class="mod">CrdSupport.java</span></div>
+              <div class="t"><span class="dot"></span><span class="mod">Extensions.java</span></div>
+              <div class="t more"><span class="dot"></span><span class="mod">… + ~600 more files, one module</span></div>
+            </div>
+          </article>
+
+          <div class="problem-panel">
+            <div class="pp-eyebrow">// imagine a project like this</div>
+            <div class="pp-statement">No module boundaries.<br/>The agent reasons about the <em>whole repo</em>, and changes <em>too much</em>.</div>
+            <div class="pp-econ">
+              <span class="k">// context &amp; economics</span>
+              the whole repo in the window: more tokens, slower loops, more wrong turns.
+            </div>
+          </div>
+        </div>
+
+        <!-- ============================================================
+             SOLUTION layer (step 1) — the REAL fabric8 repo. Maven
+             modules are the boundaries; the Vert.x change has an
+             obvious home. Proof: merged PR #7812 (manusa, 2026-05-18).
+             ============================================================ -->
+        <div class="layer layer-solution">
+          <article class="tree-panel fab">
+            <header class="panel-bar">
+              <span class="dot r"></span><span class="dot y"></span><span class="dot g"></span>
+              <span class="path">fabric8io / kubernetes-client</span>
+              <span class="grow"></span>
+              <span class="scope good">the change has a home</span>
+            </header>
+            <div class="tree">
+              <div class="t api"><span class="dot"></span><span class="mod">kubernetes-client-api/</span><span class="note">public API · <span class="seed">compiler-checked</span></span></div>
+              <div class="t"><span class="dot"></span><span class="mod">kubernetes-client/</span><span class="note">implementation</span></div>
+              <div class="t sib"><span class="dot"></span><span class="mod">httpclient-{jdk, okhttp, jetty}/</span><span class="note">other backends</span></div>
+              <div class="t hit"><span class="dot"></span><span class="mod">httpclient-{vertx, vertx-5}/</span><span class="note">the change</span></div>
+              <div class="t gen"><span class="dot"></span><span class="mod">kubernetes-model-generator/</span><span class="note">generated · don't hand-edit</span></div>
+              <div class="t"><span class="dot"></span><span class="mod">extensions/</span><span class="note">knative · tekton · istio</span></div>
+              <div class="t"><span class="dot"></span><span class="mod">openshift-client/</span><span class="note">openshift support</span></div>
+            </div>
+          </article>
+
+          <article class="pr-card">
+            <header class="panel-bar gh">
+              <span class="gh-icon"><i class="fa-brands fa-github"></i></span>
+              <span class="repo">fabric8io / kubernetes-client</span>
+              <span class="sep">·</span>
+              <a class="prnum" href="https://github.com/fabric8io/kubernetes-client/pull/7812" target="_blank" rel="noopener noreferrer">#7812</a>
+              <span class="grow"></span>
+              <span class="status merged">Merged</span>
+            </header>
+            <div class="pr-body">
+              <h3 class="pr-title"><span class="scope-tag">test:</span> use ephemeral ports in httpclient-vertx{,-5} SSL/body-stream tests</h3>
+              <div class="pr-author"><span class="avatar"><i class="fa-solid fa-user"></i></span><span class="who">manusa</span><span class="dim">merged · 2026-05-18</span></div>
+              <div class="diff">
+                <div class="row"><span class="g">±</span><span class="k">4 files</span><span class="v">+20 −12</span></div>
+                <div class="row"><span class="g">▣</span><span class="k">2 modules</span><span class="v"><code>httpclient-vertx{,-5}</code></span></div>
+                <div class="row good"><span class="g">✓</span><span class="k">0 public API</span><span class="v">· 0 generated</span></div>
+              </div>
+              <div class="pr-cap">// the change had a home.</div>
+            </div>
+          </article>
+        </div>
+      </div>
+
+      <div class="tag-line">
+        <span class="lbl">// takeaway</span>
+        <div class="quotes">
+          <span class="quote q-0">Can't tell where a change belongs? The agent <em>changes everything</em>.</span>
+          <span class="quote q-1">The safer the boundary, the <em>smaller the reasoning radius</em>.</span>
+        </div>
+      </div>
+    </div>
+
+    <div class="chrome-bottom">
+      <div class="left"><span class="brand-mark">marc nuri</span><span class="sep">|</span><span>red hat</span></div>
+      <span class="spacer"></span>
+      <div class="right"><span>devtalks.ro · 2026</span></div>
+    </div>
+  </section>
+
+  <!-- ============================================================
+       13 ACT 4 · SHAPE THE WORK UPSTREAM
+
+       The calm slide — the exhale after three dense ones. Expensive
+       reasoning once → cheap execution N times. Artifact: helm-java
+       #351 (OPEN · good first issue), short because the recipe was
+       already extracted into AGENTS.md + a named reference impl
+       (StatusCommand). Also the cost/token beat: think expensively
+       once, run cheaply N times.
+
+       Step 0 — equation + issue collapsed to title + labels.
+       Step 1 — issue body reveals (acceptance · Java-8 · ref impl);
+                the "anyone can run it" channels light up.
+       ============================================================ -->
+  <section class="s-leverage light" data-label="Act 4 — Shape the work upstream" data-step-max="1">
+    <div class="chrome-top">
+      <span class="dot"></span>
+      <span>~/dev/devtalks-2026 · manusa/helm-java/issues/351</span>
+      <span class="spacer"></span>
+      <span class="pill">act 04 · leverage · 13</span>
+    </div>
+
+    <div class="body">
+      <header class="head">
+        <div class="eyebrow">// act 04 · leverage</div>
+        <h2 class="title">Shape the work <em>upstream</em>.</h2>
+        <p class="sub">
+          Use your best reasoning to shape the work,<br/>
+          not just to <em>write the code</em>.
+        </p>
+      </header>
+
+      <div class="stage">
+        <!-- ============================================================
+             Principle (left): spend the expensive model once →
+             cheap implementation N times. Cheap half reveals on step 1.
+             ============================================================ -->
+        <div class="principle">
+          <div class="band expensive">
+            <div class="brow">
+              <span class="cost"><span class="amt">$$$</span><span class="lbl">think once</span></span>
+              <span class="bhead"><i class="fa-solid fa-brain"></i>strongest model, upstream</span>
+            </div>
+            <div class="work">understand the change · explore the codebase<br/>surface edge cases<br/>define acceptance criteria · propose the tests</div>
+          </div>
+
+          <div class="flow-arrow"><span class="arr">↓</span> produces a detailed spec</div>
+
+          <div class="band cheap">
+            <div class="brow">
+              <span class="cost"><span class="amt">¢</span><span class="lbl">× N</span></span>
+              <span class="bhead">then cheap execution</span>
+            </div>
+            <ul class="implementers">
+              <li><i class="fa-solid fa-robot"></i>a smaller, faster model</li>
+              <li><i class="fa-solid fa-user-group"></i>an external contributor</li>
+              <li><i class="fa-solid fa-clock-rotate-left"></i>future-you</li>
+            </ul>
+          </div>
+
+          <div class="spec-hint">↳ a <b>spec-driven workflow</b>: formalize it with a framework, or keep it free-form.</div>
+        </div>
+
+        <!-- ============================================================
+             Artifact (right): the real, DETAILED helm-java #351.
+             Compatibility + Validation = where the expensive thinking
+             went, so a cheap executor can run it safely.
+             ============================================================ -->
+        <article class="issue">
+          <header class="panel-bar gh">
+            <span class="gh-icon"><i class="fa-brands fa-github"></i></span>
+            <span class="repo">manusa / helm-java</span>
+            <span class="sep">·</span>
+            <a class="num" href="https://github.com/manusa/helm-java/issues/351" target="_blank" rel="noopener noreferrer">#351</a>
+            <span class="grow"></span>
+            <span class="status open">Open</span>
+          </header>
+          <div class="issue-head">
+            <h3 class="issue-title">feat: implement helm rollback command</h3>
+            <div class="labels">
+              <span class="lab enhancement">enhancement</span>
+              <span class="lab help">help wanted</span>
+              <span class="lab gfi">good first issue</span>
+            </div>
+          </div>
+          <div class="issue-body">
+            <div class="block">
+              <div class="bh">Compatibility</div>
+              <div class="ln"><span class="hot">Java 8 baseline</span> · no var, no records</div>
+              <div class="ln">additive public API only</div>
+              <div class="ln">preserve existing behavior</div>
+            </div>
+            <div class="block">
+              <div class="bh">Validation</div>
+              <div class="ln">add a JUnit regression test</div>
+              <div class="ln">run <code>./mvnw test -pl helm-java</code></div>
+              <div class="ln">don't hand-edit generated native code</div>
+            </div>
+            <div class="ref">reference impl → <code>StatusCommand.java</code></div>
+          </div>
+        </article>
+      </div>
+
+      <div class="tag-line">
+        <span class="lbl">// takeaway</span>
+        <div class="quotes">
+          <span class="quote q-0">Spend the expensive model on the <em>problem</em>, not the typing.</span>
+          <span class="quote q-1">Cheap implementation is possible when the problem was <em>expensive to think through</em>.</span>
         </div>
       </div>
     </div>

--- a/static/presentations/2026-devtalks-romania/styles/s-boundaries.css
+++ b/static/presentations/2026-devtalks-romania/styles/s-boundaries.css
@@ -1,0 +1,458 @@
+/* ============================================================
+   .s-boundaries — Act 4, slide 12.
+   "Make Java boundaries obvious."
+
+   Two distinct beats, two different repositories:
+
+   Step 0 — THE PROBLEM (a HYPOTHETICAL structure).
+     "Imagine a project like this": one module, one package, ~600
+     files all mixed. No boundaries → the agent reasons about the
+     whole repo and changes too much (and pays for the whole repo
+     in context). The structure tells the agent nothing.
+
+   Step 1 — THE FABRIC8 ANSWER (the real repo).
+     Real fabric8/kubernetes-client module tree — the structure
+     tells the agent exactly where a Vert.x change belongs. The
+     Vert.x pair goes green, role annotations are visible, and the
+     real merged PR #7812 proves it: 4 files, 2 modules, 0 public
+     API, 0 generated.
+
+   Content type sizes are held at >=20px (trees, notes, panel
+   bodies, captions). Only chrome shared with the rest of the deck
+   (panel-bar paths, status pills, the // labels) stays smaller.
+
+   Theme: .light slide (cream paper); trees stay dark terminals so
+   they read as files, same idiom as s-agents-md.
+   ============================================================ */
+
+/* Faint dotted grid — atmosphere only, same as s-agents-md */
+.s-boundaries::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background-image: radial-gradient(circle, var(--grid) 1.2px, transparent 1.4px);
+  background-size: 44px 44px;
+  pointer-events: none;
+  z-index: 0;
+}
+
+/* ============================================================
+   Body grid — header / stage / tagline
+   ============================================================ */
+.s-boundaries .body {
+  position: absolute;
+  inset: 56px 0 56px 0;
+  z-index: 1;
+  padding: 36px var(--pad-x) 40px;
+  display: grid;
+  grid-template-rows: auto 1fr auto;
+  row-gap: 22px;
+}
+
+/* === Header — same construction as s-agents-md === */
+.s-boundaries .head {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  align-items: end;
+  column-gap: 48px;
+}
+.s-boundaries .head .eyebrow {
+  grid-column: 1;
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 20px;
+  letter-spacing: 0.18em;
+  text-transform: lowercase;
+  color: var(--accent-ink);
+  margin-bottom: 14px;
+}
+.s-boundaries .head .title {
+  grid-column: 1;
+  font-size: 64px;
+  line-height: 1.06;
+  letter-spacing: -0.02em;
+  font-weight: 700;
+  margin: 0;
+  color: var(--fg);
+}
+.s-boundaries .head .title em {
+  font-style: normal;
+  color: var(--accent);
+}
+.s-boundaries .head .sub {
+  grid-column: 2;
+  margin: 0 0 8px 0;
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 20px;
+  line-height: 1.45;
+  color: var(--fg-dim);
+  text-align: right;
+}
+.s-boundaries .head .sub em {
+  font-style: normal;
+  color: var(--accent-ink);
+  font-weight: 600;
+}
+
+/* ============================================================
+   Stage — two full-width layers cross-fade: the hypothetical
+   problem (step 0) and the real Fabric8 answer (step 1).
+   ============================================================ */
+.s-boundaries .stage {
+  position: relative;
+  min-height: 460px;
+}
+.s-boundaries .layer {
+  position: absolute;
+  inset: 0;
+  display: grid;
+  grid-template-columns: minmax(0, 1.18fr) minmax(0, 1fr);
+  column-gap: 44px;
+  align-items: center;
+  align-content: center;
+  transition:
+    opacity 400ms cubic-bezier(.2, .7, .2, 1),
+    transform 400ms cubic-bezier(.2, .7, .2, 1);
+}
+.s-boundaries .layer-problem  { opacity: 1; }
+.s-boundaries .layer-solution { opacity: 0; transform: translateY(12px); pointer-events: none; }
+.s-boundaries[data-step="1"] .layer-problem  { opacity: 0; transform: translateY(-12px); pointer-events: none; }
+.s-boundaries[data-step="1"] .layer-solution { opacity: 1; transform: none; pointer-events: auto; }
+
+/* ============================================================
+   Tree panel (dark terminal) — shared by the synthetic monolith
+   and the real Fabric8 tree.
+   ============================================================ */
+.s-boundaries .tree-panel {
+  align-self: stretch;
+  background: #060D3A;
+  border: 1px solid rgba(10, 21, 84, 0.22);
+  border-radius: 10px;
+  overflow: hidden;
+  box-shadow:
+    0 24px 60px rgba(10, 21, 84, 0.20),
+    0 4px 12px rgba(10, 21, 84, 0.10);
+  display: flex;
+  flex-direction: column;
+}
+.s-boundaries .tree-panel .panel-bar {
+  display: flex;
+  align-items: center;
+  gap: 9px;
+  padding: 14px 22px;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.08);
+  background: rgba(255, 255, 255, 0.03);
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 16px;
+  color: #8A93BC;
+  letter-spacing: 0.04em;
+  flex-shrink: 0;
+}
+.s-boundaries .tree-panel .panel-bar .dot { width: 11px; height: 11px; border-radius: 50%; }
+.s-boundaries .tree-panel .panel-bar .dot.r { background: #FF5F57; }
+.s-boundaries .tree-panel .panel-bar .dot.y { background: #FEBC2E; }
+.s-boundaries .tree-panel .panel-bar .dot.g { background: #28C840; }
+.s-boundaries .tree-panel .panel-bar .path { margin-left: 14px; color: #B4BAD8; }
+.s-boundaries .tree-panel .panel-bar .grow { flex: 1; }
+
+/* reasoning-surface badge — red on the monolith, green on Fabric8 */
+.s-boundaries .tree-panel .scope {
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 15px;
+  letter-spacing: 0.02em;
+  padding: 4px 12px;
+  border-radius: 999px;
+  white-space: nowrap;
+}
+.s-boundaries .tree-panel .scope.bad {
+  color: #FF8E8E;
+  background: rgba(229, 72, 77, 0.16);
+  border: 1px solid rgba(229, 72, 77, 0.45);
+}
+.s-boundaries .tree-panel .scope.good {
+  color: #5CE08A;
+  background: rgba(40, 200, 64, 0.14);
+  border: 1px solid rgba(40, 200, 64, 0.45);
+}
+
+.s-boundaries .tree-panel .tree {
+  padding: 20px 28px 22px;
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 22px;
+  line-height: 1.5;
+  color: #C8CCE4;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  justify-content: center;
+  flex: 1;
+}
+
+/* structural (non-module) lines in the synthetic tree: root + src */
+.s-boundaries .tree-panel .tline { color: #8A93BC; }
+.s-boundaries .tree-panel .tline.sub { color: #6B75A6; padding-left: 20px; }
+
+/* a module / file row = scope dot + name + (optional) role note */
+.s-boundaries .t {
+  display: flex;
+  align-items: center;
+  gap: 13px;
+  padding-left: 7px;
+  border-left: 3px solid transparent;
+  margin-left: -10px;
+}
+.s-boundaries .t .dot {
+  width: 11px; height: 11px; border-radius: 50%;
+  flex-shrink: 0;
+  background: #3A4470;
+}
+.s-boundaries .t .mod { color: #C8CCE4; }
+.s-boundaries .t .note {
+  margin-left: 6px;
+  font-size: 20px;
+  color: #7C86B4;
+  letter-spacing: 0.01em;
+  white-space: nowrap;
+}
+.s-boundaries .t .note .seed { color: #8A93BC; }   /* compiler forward-ref, understated */
+
+/* ---------- Synthetic monolith (step 0) — everything red, in scope ---------- */
+.s-boundaries .synth .t { padding-left: 40px; }     /* nested deep under one src root */
+.s-boundaries .synth .t .dot { background: #E5484D; }
+.s-boundaries .synth .t .mod { color: #EDEFFB; }
+.s-boundaries .synth .t.more .mod { color: #9AA2CC; font-style: italic; }
+.s-boundaries .synth .t.more .dot { background: rgba(229, 72, 77, 0.55); }
+
+/* ---------- Real Fabric8 tree (step 1) — modules are siblings ---------- */
+.s-boundaries .fab .t.hit .dot { background: #28C840; }
+.s-boundaries .fab .t.hit { border-left-color: #28C840; }
+.s-boundaries .fab .t.hit .mod { color: #FFFFFF; font-weight: 600; }
+.s-boundaries .fab .t.api .note { color: var(--cyan); }
+.s-boundaries .fab .t.gen .mod { color: var(--orange-soft); }
+.s-boundaries .fab .t.gen .note { color: var(--orange-soft); }
+.s-boundaries .fab .t.hit .note { color: #5CE08A; }
+
+/* ============================================================
+   Problem panel (step 0, right column)
+   ============================================================ */
+.s-boundaries .problem-panel {
+  align-self: stretch;
+  background: #FFFFFF;
+  border: 1px solid #D1D9E0;
+  border-left: 4px solid var(--accent);
+  border-radius: 10px;
+  box-shadow:
+    0 18px 40px rgba(10, 21, 84, 0.14),
+    0 4px 10px rgba(10, 21, 84, 0.06);
+  padding: 30px 34px;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  gap: 20px;
+}
+.s-boundaries .problem-panel .pp-eyebrow {
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 20px;
+  letter-spacing: 0.04em;
+  color: var(--accent-ink);
+  font-weight: 600;
+}
+.s-boundaries .problem-panel .pp-statement {
+  font-family: 'Inter', system-ui, sans-serif;
+  font-size: 31px;
+  font-weight: 700;
+  line-height: 1.2;
+  letter-spacing: -0.01em;
+  color: var(--fg);
+}
+.s-boundaries .problem-panel .pp-statement em {
+  font-style: normal;
+  color: var(--accent-ink);
+}
+.s-boundaries .problem-panel .pp-econ {
+  border-top: 1px solid #E4E7EC;
+  padding-top: 18px;
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 20px;
+  line-height: 1.45;
+  color: var(--fg-dim);
+}
+.s-boundaries .problem-panel .pp-econ .k {
+  display: block;
+  font-size: 16px;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: var(--fg-mute);
+  margin-bottom: 6px;
+}
+
+/* ============================================================
+   PR card (step 1, right column) — reuses the slide-14 idiom
+   ============================================================ */
+.s-boundaries .pr-card {
+  align-self: stretch;
+  background: #FFFFFF;
+  border: 1px solid #D1D9E0;
+  border-radius: 10px;
+  overflow: hidden;
+  box-shadow:
+    0 18px 40px rgba(10, 21, 84, 0.16),
+    0 4px 10px rgba(10, 21, 84, 0.08);
+  display: flex;
+  flex-direction: column;
+}
+.s-boundaries .pr-card .panel-bar.gh {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 14px 20px;
+  background: #F6F8FA;
+  border-bottom: 1px solid #D1D9E0;
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 16px;
+  letter-spacing: 0.02em;
+  color: #59636E;
+}
+.s-boundaries .pr-card .panel-bar.gh .gh-icon { color: #1F2328; font-size: 18px; }
+.s-boundaries .pr-card .panel-bar.gh .repo { color: #1F2328; font-weight: 600; }
+.s-boundaries .pr-card .panel-bar.gh .sep { color: #59636E; }
+.s-boundaries .pr-card .panel-bar.gh .prnum { color: #59636E; text-decoration: none; }
+.s-boundaries .pr-card .panel-bar.gh .prnum:hover { color: #0969DA; text-decoration: underline; }
+.s-boundaries .pr-card .panel-bar.gh .grow { flex: 1; }
+.s-boundaries .pr-card .panel-bar.gh .status.merged {
+  font-size: 14px;
+  font-weight: 600;
+  padding: 4px 12px;
+  border-radius: 999px;
+  color: #FFFFFF;
+  background: #8250DF;
+  border: 1px solid #6F42C1;
+}
+
+.s-boundaries .pr-card .pr-body {
+  padding: 22px 26px 22px;
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  flex: 1;
+  justify-content: center;
+  font-family: 'Inter', system-ui, sans-serif;
+  color: #1F2328;
+}
+.s-boundaries .pr-card .pr-title {
+  margin: 0;
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 21px;
+  line-height: 1.4;
+  font-weight: 500;
+  color: #1F2328;
+}
+.s-boundaries .pr-card .pr-title .scope-tag { color: #0550AE; font-weight: 600; }
+.s-boundaries .pr-card .pr-author {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 20px;
+  color: #59636E;
+}
+.s-boundaries .pr-card .pr-author .avatar {
+  width: 30px; height: 30px; border-radius: 50%;
+  background: #B81742;
+  color: #FFFFFF;
+  display: inline-flex; align-items: center; justify-content: center;
+  font-size: 15px; flex-shrink: 0;
+}
+.s-boundaries .pr-card .pr-author .who { color: #1F2328; font-weight: 600; }
+.s-boundaries .pr-card .pr-author .dim { color: #59636E; }
+
+.s-boundaries .pr-card .diff {
+  display: flex;
+  flex-direction: column;
+  gap: 9px;
+  padding: 16px 18px;
+  background: #DAFBE1;
+  border: 1px solid #A2E5A2;
+  border-radius: 8px;
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 20px;
+}
+.s-boundaries .pr-card .diff .row {
+  display: flex;
+  align-items: baseline;
+  gap: 12px;
+  color: #1F2328;
+}
+.s-boundaries .pr-card .diff .row .g { color: #1A7F37; font-weight: 700; min-width: 18px; }
+.s-boundaries .pr-card .diff .row .k { color: #1F2328; font-weight: 600; min-width: 132px; }
+.s-boundaries .pr-card .diff .row .v { color: #59636E; }
+.s-boundaries .pr-card .diff .row.good .k,
+.s-boundaries .pr-card .diff .row.good .v { color: #1A7F37; font-weight: 600; }
+.s-boundaries .pr-card .diff .row code {
+  color: #6F42C1;
+  background: rgba(130, 80, 223, 0.08);
+  border: 1px solid rgba(130, 80, 223, 0.20);
+  border-radius: 4px;
+  padding: 0 7px;
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 18px;
+}
+.s-boundaries .pr-card .pr-cap {
+  margin-top: 4px;
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 20px;
+  color: var(--accent-ink);
+  font-weight: 600;
+}
+
+/* ============================================================
+   Tag line — morphs between step 0 (problem) and step 1 (payoff)
+   ============================================================ */
+.s-boundaries .tag-line {
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  min-height: 56px;
+}
+.s-boundaries .tag-line .lbl {
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 16px;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  color: var(--fg-mute);
+}
+.s-boundaries .tag-line .quotes {
+  position: relative;
+  min-height: 40px;
+}
+.s-boundaries .tag-line .quote {
+  font-size: 32px;
+  font-weight: 600;
+  line-height: 1.2;
+  color: var(--fg);
+  letter-spacing: -0.005em;
+  text-wrap: balance;
+  transition: opacity 350ms cubic-bezier(.2, .7, .2, 1);
+}
+.s-boundaries .tag-line .quote em {
+  font-style: normal;
+  color: var(--accent-ink);
+}
+.s-boundaries .tag-line .quote.q-1 {
+  position: absolute;
+  inset: 0;
+  opacity: 0;
+}
+.s-boundaries[data-step="1"] .tag-line .quote.q-0 { opacity: 0; }
+.s-boundaries[data-step="1"] .tag-line .quote.q-1 { opacity: 1; }
+
+/* ============================================================
+   Print — drop heavy shadows so Chromium's page.pdf() doesn't
+   rasterise them as opaque rectangles. export:pdf renders both
+   steps; the cross-fade leaves the right layer on top per page.
+   ============================================================ */
+@media print {
+  .s-boundaries .tree-panel,
+  .s-boundaries .problem-panel,
+  .s-boundaries .pr-card { box-shadow: none; }
+}

--- a/static/presentations/2026-devtalks-romania/styles/s-leverage.css
+++ b/static/presentations/2026-devtalks-romania/styles/s-leverage.css
@@ -1,0 +1,391 @@
+/* ============================================================
+   .s-leverage — Act 4, slide 13.
+   "Shape the work upstream."
+
+   The economics of delegation, made concrete:
+
+     PRINCIPLE (left) — spend your strongest, most EXPENSIVE model
+       once, upstream: understand, explore, surface edge cases,
+       acceptance criteria, tests. That produces a detailed spec.
+       Then implementation is CHEAP and runs N times — a smaller
+       model, an external contributor, or future-you.
+
+     ARTIFACT (right) — a real, DETAILED issue (helm-java #351,
+       "good first issue") with Compatibility + Validation blocks.
+       Detailed on purpose: that is where the expensive thinking
+       went, so a cheap executor can run it safely.
+
+   Step 0 — the expensive upstream half + the detailed issue.
+   Step 1 — the cheap-execution half lights up (smaller model ·
+            contributor · future-you), the takeaway lands.
+
+   A lightweight spec-driven workflow; the slide hints at going
+   deeper. Content type sizes held at >=20px.
+   ============================================================ */
+
+/* Faint dotted grid — atmosphere only, same idiom as siblings */
+.s-leverage::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background-image: radial-gradient(circle, var(--grid) 1.2px, transparent 1.4px);
+  background-size: 44px 44px;
+  pointer-events: none;
+  z-index: 0;
+}
+
+/* ============================================================
+   Body grid — header / stage / tagline
+   ============================================================ */
+.s-leverage .body {
+  position: absolute;
+  inset: 56px 0 56px 0;
+  z-index: 1;
+  padding: 34px var(--pad-x) 40px;
+  display: grid;
+  grid-template-rows: auto 1fr auto;
+  row-gap: 20px;
+}
+
+/* === Header — same construction as s-agents-md / s-skill === */
+.s-leverage .head {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  align-items: end;
+  column-gap: 48px;
+}
+.s-leverage .head .eyebrow {
+  grid-column: 1;
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 20px;
+  letter-spacing: 0.18em;
+  text-transform: lowercase;
+  color: var(--accent-ink);
+  margin-bottom: 14px;
+}
+.s-leverage .head .title {
+  grid-column: 1;
+  font-size: 64px;
+  line-height: 1.06;
+  letter-spacing: -0.02em;
+  font-weight: 700;
+  margin: 0;
+  color: var(--fg);
+}
+.s-leverage .head .title em {
+  font-style: normal;
+  color: var(--accent);
+}
+.s-leverage .head .sub {
+  grid-column: 2;
+  margin: 0 0 8px 0;
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 20px;
+  line-height: 1.5;
+  color: var(--fg-dim);
+  text-align: right;
+}
+.s-leverage .head .sub em { font-style: normal; color: var(--accent-ink); font-weight: 600; }
+
+/* ============================================================
+   Stage — principle (left) + artifact (right)
+   ============================================================ */
+.s-leverage .stage {
+  position: relative;
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) minmax(0, 1.02fr);
+  column-gap: 52px;
+  align-items: start;       /* both columns share a top edge */
+  align-content: center;    /* …and the pair centers in the stage band */
+}
+
+/* ---------- Principle (left): expensive → cheap ---------- */
+.s-leverage .principle {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+.s-leverage .band {
+  background: #FFFFFF;
+  border: 1px solid #D1D9E0;
+  border-radius: 10px;
+  padding: 18px 22px;
+  box-shadow: 0 8px 20px rgba(10, 21, 84, 0.08);
+}
+.s-leverage .band.expensive { border-left: 4px solid var(--accent-2); }
+.s-leverage .band.cheap {
+  border-left: 4px solid var(--cyan-ink);
+  opacity: 0.42;                       /* dim but legible until the reveal */
+  transition:
+    opacity 400ms cubic-bezier(.2, .7, .2, 1),
+    background 400ms cubic-bezier(.2, .7, .2, 1);
+}
+.s-leverage[data-step="1"] .band.cheap {
+  opacity: 1;
+  background: linear-gradient(90deg, rgba(8, 105, 120, 0.06), #FFFFFF 60%);
+}
+
+.s-leverage .band .brow {
+  display: flex;
+  align-items: baseline;
+  gap: 12px;
+  margin-bottom: 10px;
+}
+.s-leverage .band .cost {
+  display: inline-flex;
+  align-items: baseline;
+  gap: 7px;
+  font-family: 'JetBrains Mono', monospace;
+  flex-shrink: 0;
+}
+.s-leverage .band .cost .amt { font-size: 23px; font-weight: 700; letter-spacing: -0.01em; }
+.s-leverage .band .cost .lbl { font-size: 16px; font-weight: 600; letter-spacing: 0.1em; text-transform: uppercase; }
+.s-leverage .band.expensive .cost .amt { color: var(--accent-2-ink); font-size: 25px; }
+.s-leverage .band.expensive .cost .lbl { color: var(--accent-2-ink); }
+.s-leverage .band.cheap .cost .amt { color: var(--cyan-ink); }
+.s-leverage .band.cheap .cost .lbl { color: var(--cyan-ink); }
+.s-leverage .band .bhead {
+  font-family: 'Inter', system-ui, sans-serif;
+  font-size: 23px;
+  font-weight: 700;
+  letter-spacing: -0.01em;
+  color: var(--fg);
+}
+.s-leverage .band.expensive .bhead i { color: var(--accent-2-ink); margin-right: 4px; }
+
+.s-leverage .band .work {
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 20px;
+  line-height: 1.5;
+  color: var(--fg-dim);
+}
+.s-leverage .band .implementers {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 7px;
+}
+.s-leverage .band .implementers li {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  font-family: 'Inter', system-ui, sans-serif;
+  font-size: 21px;
+  color: var(--fg);
+}
+.s-leverage .band .implementers li i {
+  color: var(--cyan-ink);
+  width: 26px;
+  text-align: center;
+  font-size: 19px;
+  flex-shrink: 0;
+}
+
+/* connector between the two bands */
+.s-leverage .flow-arrow {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding-left: 8px;
+  font-family: 'JetBrains Mono', monospace;
+  color: var(--fg-dim);
+  font-size: 19px;
+}
+.s-leverage .flow-arrow .arr { color: var(--accent-ink); font-weight: 700; font-size: 24px; }
+
+/* spec-driven hint */
+.s-leverage .spec-hint {
+  margin-top: 4px;
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 18px;
+  line-height: 1.45;
+  color: var(--fg-mute);
+}
+.s-leverage .spec-hint b { color: var(--fg-dim); font-weight: 600; }
+
+/* ---------- Artifact (right): the detailed helm-java #351 issue ---------- */
+.s-leverage .issue {
+  align-self: start;
+  background: #FFFFFF;
+  border: 1px solid #D1D9E0;
+  border-radius: 10px;
+  overflow: hidden;
+  box-shadow:
+    0 18px 40px rgba(10, 21, 84, 0.16),
+    0 4px 10px rgba(10, 21, 84, 0.08);
+  display: flex;
+  flex-direction: column;
+}
+.s-leverage .issue .panel-bar.gh {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 13px 20px;
+  background: #F6F8FA;
+  border-bottom: 1px solid #D1D9E0;
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 16px;
+  letter-spacing: 0.02em;
+  color: #59636E;
+}
+.s-leverage .issue .panel-bar.gh .gh-icon { color: #1F2328; font-size: 18px; }
+.s-leverage .issue .panel-bar.gh .repo { color: #1F2328; font-weight: 600; }
+.s-leverage .issue .panel-bar.gh .sep { color: #59636E; }
+.s-leverage .issue .panel-bar.gh .num { color: #59636E; text-decoration: none; }
+.s-leverage .issue .panel-bar.gh .num:hover { color: #0969DA; text-decoration: underline; }
+.s-leverage .issue .panel-bar.gh .grow { flex: 1; }
+.s-leverage .issue .panel-bar.gh .status.open {
+  font-size: 14px;
+  font-weight: 600;
+  padding: 4px 12px;
+  border-radius: 999px;
+  color: #FFFFFF;
+  background: #1F883D;
+  border: 1px solid #1A7F37;
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+}
+.s-leverage .issue .panel-bar.gh .status.open::before {
+  content: "";
+  width: 8px; height: 8px; border-radius: 50%;
+  background: #FFFFFF;
+}
+
+.s-leverage .issue .issue-head {
+  padding: 16px 24px 14px;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  font-family: 'Inter', system-ui, sans-serif;
+  color: #1F2328;
+  border-bottom: 1px solid #E4E7EC;
+}
+.s-leverage .issue .issue-title {
+  margin: 0;
+  font-size: 24px;
+  line-height: 1.3;
+  font-weight: 600;
+  letter-spacing: -0.005em;
+  color: #1F2328;
+}
+.s-leverage .issue .labels { display: flex; flex-wrap: wrap; gap: 8px; }
+.s-leverage .issue .labels .lab {
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 14px;
+  font-weight: 600;
+  padding: 3px 12px;
+  border-radius: 999px;
+  line-height: 1.4;
+}
+.s-leverage .issue .labels .lab.enhancement { background: #A2EEEF; color: #044E54; }
+.s-leverage .issue .labels .lab.help        { background: #008672; color: #FFFFFF; }
+.s-leverage .issue .labels .lab.gfi         { background: #7057FF; color: #FFFFFF; }
+
+.s-leverage .issue .issue-body {
+  padding: 18px 24px 20px;
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 20px;
+  line-height: 1.5;
+  color: #1F2328;
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+}
+.s-leverage .issue .block .bh {
+  font-weight: 700;
+  color: #0550AE;
+  margin-bottom: 4px;
+}
+.s-leverage .issue .block .ln {
+  display: flex;
+  align-items: baseline;
+  gap: 10px;
+  color: #1F2328;
+}
+.s-leverage .issue .block .ln::before {
+  content: "−";
+  color: #6E7781;
+  font-weight: 700;
+}
+.s-leverage .issue .block .ln code {
+  color: #6F42C1;
+  background: rgba(130, 80, 223, 0.08);
+  border: 1px solid rgba(130, 80, 223, 0.20);
+  border-radius: 4px;
+  padding: 0 6px;
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 18px;
+}
+.s-leverage .issue .block .ln .hot {
+  color: #A04707;
+  font-weight: 600;
+}
+.s-leverage .issue .ref {
+  border-top: 1px dashed #D1D9E0;
+  padding-top: 12px;
+  font-size: 18px;
+  color: #59636E;
+}
+.s-leverage .issue .ref code {
+  color: #6F42C1;
+  background: rgba(130, 80, 223, 0.08);
+  border: 1px solid rgba(130, 80, 223, 0.20);
+  border-radius: 4px;
+  padding: 0 6px;
+  font-size: 16px;
+}
+
+/* ============================================================
+   Tag line — morphs between step 0 (principle) and step 1 (payoff)
+   ============================================================ */
+.s-leverage .tag-line {
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  min-height: 56px;
+}
+.s-leverage .tag-line .lbl {
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 16px;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  color: var(--fg-mute);
+}
+.s-leverage .tag-line .quotes {
+  position: relative;
+  min-height: 40px;
+}
+.s-leverage .tag-line .quote {
+  font-size: 32px;
+  font-weight: 600;
+  line-height: 1.2;
+  color: var(--fg);
+  letter-spacing: -0.005em;
+  text-wrap: balance;
+  transition: opacity 350ms cubic-bezier(.2, .7, .2, 1);
+}
+.s-leverage .tag-line .quote em {
+  font-style: normal;
+  color: var(--accent-ink);
+}
+.s-leverage .tag-line .quote.q-1 {
+  position: absolute;
+  inset: 0;
+  opacity: 0;
+}
+.s-leverage[data-step="1"] .tag-line .quote.q-0 { opacity: 0; }
+.s-leverage[data-step="1"] .tag-line .quote.q-1 { opacity: 1; }
+
+/* ============================================================
+   Print — drop heavy shadows for PDF export; both steps render,
+   so the cheap band must be legible (force opacity up in print).
+   ============================================================ */
+@media print {
+  .s-leverage .issue,
+  .s-leverage .band { box-shadow: none; border-color: #B8C2CC; }
+  .s-leverage .band.cheap { opacity: 1; }
+}


### PR DESCRIPTION
Fills the Act 4 ("Map · Roads") gap between AGENTS.md (slide 11) and SKILL.md (slide 14) in the DevTalks Romania 2026 deck.

## Slide 12 — Make Java boundaries obvious
Two cross-fading beats:
- **Problem:** a hypothetical monolith (one module, no boundaries) — the agent reasons about the whole repo and changes too much.
- **Answer:** the real `fabric8io/kubernetes-client` module tree gives a Vert.x change an obvious home. Merged PR #7812 proves it: 4 files, 2 modules, 0 public API, 0 generated.

## Slide 13 — Shape the work upstream
The economics of delegation:
- Spend your strongest, most expensive model **once** upstream (understand the change, explore, surface edge cases, acceptance criteria, tests) to produce a detailed spec.
- Then implementation is **cheap** and runs N times: a smaller model, an external contributor, or future-you.
- Artifact: helm-java issue #351 ("good first issue") with Compatibility + Validation blocks; nods to spec-driven workflows.

Both reuse the deck's existing idioms (dark terminal panels, GitHub card family, morphing takeaway, `data-step` reveals) — no new primitives. Content type sizes held ≥20px.