### PR TITLE
✨ devtalks-2026: extend Guardrails spine — fa-shield watermark on Act 5

### DIFF
--- a/static/presentations/2026-devtalks-romania/index.html
+++ b/static/presentations/2026-devtalks-romania/index.html
@@ -2355,6 +2355,7 @@
     </div>
 
     <div class="body">
+      <i class="pillar-watermark guard-watermark fa-solid fa-shield-halved" aria-hidden="true"></i>
       <header class="head">
         <div class="eyebrow">// act 05 · the codebase pushes back</div>
         <!-- Two-step reveal: step 0 shows only "Specs explain intent." (the
@@ -2493,6 +2494,7 @@
     </div>
 
     <div class="body">
+      <i class="pillar-watermark guard-watermark fa-solid fa-shield-halved" aria-hidden="true"></i>
       <header class="head">
         <div class="eyebrow">// act 05 · same failure · richer signal</div>
         <h2 class="title">A failing test should <em>explain</em> the broken behavior.</h2>
@@ -2630,6 +2632,7 @@
     </div>
 
     <div class="body">
+      <i class="pillar-watermark guard-watermark fa-solid fa-shield-halved" aria-hidden="true"></i>
       <header class="head">
         <div class="eyebrow">// act 05 · the unit shifts</div>
         <h2 class="title">Black-box tests: the unit is <em>behavior</em>.</h2>
@@ -2883,6 +2886,7 @@
     </div>
 
     <div class="body">
+      <i class="pillar-watermark guard-watermark fa-solid fa-shield-halved" aria-hidden="true"></i>
       <header class="head">
         <div class="eyebrow">// act 05 · one of many recent agent-assisted PRs</div>
         <h2 class="title">Black-box tests unlocked a <em>large change</em>.</h2>
@@ -3070,6 +3074,7 @@
     </div>
 
     <div class="body">
+      <i class="pillar-watermark guard-watermark fa-solid fa-shield-halved" aria-hidden="true"></i>
       <header class="head">
         <div class="eyebrow">
           <span class="eb-0">// act 05 · the loop you remember</span>
@@ -3331,6 +3336,7 @@
     </div>
 
     <div class="body">
+      <i class="pillar-watermark guard-watermark fa-solid fa-shield-halved" aria-hidden="true"></i>
       <header class="head">
         <div class="eyebrow">// act 05 · the feedback loop you can't fit in a unit test</div>
         <h2 class="title">Tech debt is <em>not optional polish.</em> It <em>caps throughput.</em></h2>
@@ -3606,6 +3612,7 @@
     </div>
 
     <div class="body">
+      <i class="pillar-watermark guard-watermark fa-solid fa-shield-halved" aria-hidden="true"></i>
       <header class="head">
         <h2 class="title">Did I just advertise <em>XP</em>?</h2>
       </header>

--- a/static/presentations/2026-devtalks-romania/styles/s-xp-reframe.css
+++ b/static/presentations/2026-devtalks-romania/styles/s-xp-reframe.css
@@ -7,6 +7,7 @@
 .s-xp-reframe .body {
   position: absolute;
   inset: 56px 0 56px 0;
+  z-index: 1;                /* stacking context so the pillar-watermark (z-index:-1) sits above the section grid */
   padding: 96px var(--pad-x) 84px;
   display: grid;
   grid-template-rows: auto 1fr auto;

--- a/static/presentations/2026-devtalks-romania/styles/shared.css
+++ b/static/presentations/2026-devtalks-romania/styles/shared.css
@@ -193,9 +193,10 @@ deck-stage section {
 
 /* ============================================================
    Pillar watermark — large, faint Map · Roads · Guardrails glyph
-   (fa-map / fa-road) echoing the recap pillar cards, anchored
-   bottom-right of a slide body. Used on the Act 4 slides whose
-   act divider declares @Delivers(...).
+   (fa-map / fa-road / fa-shield-halved) echoing the recap pillar
+   cards, anchored bottom-right of a slide body. Used on the Act 4
+   (Map, Roads) and Act 5 (Guardrails) content slides, whose act
+   dividers declare @Delivers(...).
 
    Stacking: every host .body is position:absolute; z-index:1 and
    transparent, so a z-index:-1 child paints below all body content
@@ -217,5 +218,6 @@ deck-stage section {
   pointer-events: none;
   z-index: -1;
 }
-.map-watermark  { color: var(--cyan-ink); }      /* Map   — cream-safe teal */
-.road-watermark { color: var(--accent-2-ink); }  /* Roads — cream-safe orange */
+.map-watermark   { color: var(--cyan-ink); }      /* Map        — cream-safe teal */
+.road-watermark  { color: var(--accent-2-ink); }  /* Roads      — cream-safe orange */
+.guard-watermark { color: var(--accent-ink); }    /* Guardrails — cream-safe pink */


### PR DESCRIPTION
The Act 5 divider declares @Delivers(Guardrails), so every Act 5 content slide is the Guardrails pillar. Give each one the same faint pillar watermark Act 4 uses for Map (fa-map) and Roads (fa-road): a fa-shield-halved glyph, bottom-right, bleeding off the corner. Act 4 + Act 5 now read as one Map · Roads · Guardrails statement the recap collects, instead of the recap meeting the frame cold.

- shared.css: add .guard-watermark (cream-safe pink, --accent-ink), reusing the existing .pillar-watermark base (300px, opacity 0.06, z-index:-1, anchored bottom:0 so it never spills into the footer).
- index.html: insert the watermark <i> as the first child of .body on all 7 Act 5 slides (specs-vs-tests, failure-spec, blackbox, project-story, feedback-ladder, ci, xp-reframe).
- s-xp-reframe.css: add z-index:1 to .body (the only Act 5 slide that lacked it) so the z-index:-1 glyph stacks above the section grid.

Verified by bottom-right crops on every Act 5 slide (20-26): glyph renders, content occludes it / shows through gaps, clear of the chrome-bottom footer. snapshot:diff reports identical, the known anti-aliasing blind spot for the 0.06-opacity glyph (geometry, not pixel diff, is ground truth here).