### PR TITLE
feat(deck-kit): add data-deck-present-skip for per-venue slide cuts

### DIFF
--- a/static/deck-kit/README.md
+++ b/static/deck-kit/README.md
@@ -73,7 +73,12 @@ implementation detail and may change without a filename bump.
 ### `<section>` attributes (read by deck-stage)
 
 - `data-label` — text shown in the rail; required for legible nav.
-- `data-deck-skip` — exclude this section from rail nav + keyboard advance.
+- `data-deck-present-skip` — hop over this section in prev/next navigation
+  **only while presenting** (standalone fullscreen, or a host posting
+  `__omelette_presenting`). Off-stage it stays a normal, navigable slide
+  carrying a "Skipped" watermark, and it still prints to PDF. Use it to drop
+  a slide from one delivery (e.g. a shorter conference slot) without removing
+  it from the deck or the handout.
 - `data-step-max="N"` — N+1 reveal states (`data-step="0".."N"`). Advance keys
   (ArrowRight / PageDown / Space / Enter) bump `data-step` until it reaches
   `N`, then resume slide advance; retreat keys (ArrowLeft / PageUp) mirror.
@@ -124,9 +129,9 @@ listeners attach either on the `<deck-stage>` element or on `document`.
 - `slidechange` — fires on every slide transition, including the initial
   mount. `event.detail = { index, previousIndex, total, slide, previousSlide, reason }`
   where `reason ∈ { 'init', 'keyboard', 'click', 'tap', 'api', 'mutation' }`.
-- `deckchange` — fires on rail-driven mutations (move / skip / unskip / delete).
+- `deckchange` — fires on rail-driven mutations (move / delete).
   `event.detail = { action, from, to?, slide }` where
-  `action ∈ { 'delete', 'skip', 'unskip', 'move' }` (`to` only present for `'move'`).
+  `action ∈ { 'delete', 'move' }` (`to` only present for `'move'`).
 
 ### `<deck-stage>` JavaScript API
 

--- a/static/deck-kit/deck-stage.js
+++ b/static/deck-kit/deck-stage.js
@@ -13,18 +13,24 @@
  *      PPTX exporter sets this so its DOM capture sees unscaled geometry.
  *  (f) print — `@media print` lays every slide out as its own page at the
  *      design size, so the browser's Print → Save as PDF produces a clean
- *      one-page-per-slide PDF with no extra setup.
+ *      one-page-per-slide PDF with no extra setup. `data-deck-present-skip`
+ *      slides print normally — they're dropped from live nav, not the deck.
  *  (g) thumbnail rail — resizable left-hand column of per-slide thumbnails
  *      (static clones). Click to navigate; ↑/↓ with a thumbnail focused to
  *      step between slides; drag to reorder; right-click for
- *      Skip / Move up / Move down / Delete (opens a Cancel/Delete confirm
+ *      Move up / Move down / Delete (opens a Cancel/Delete confirm
  *      dialog). Drag the rail's right edge to resize; width persists to
- *      localStorage. Skipped slides carry `data-deck-skip`, are dimmed in
- *      the rail, omitted from prev/next navigation, and hidden at print.
- *      The rail is suppressed in presenting mode, in the host's Preview
- *      mode (ViewerMode='none'), on `noscale`, and via the `no-rail`
- *      attribute. Rail mutations dispatch a `deckchange`
+ *      localStorage. The rail is suppressed in presenting mode, in the
+ *      host's Preview mode (ViewerMode='none'), on `noscale`, and via the
+ *      `no-rail` attribute. Rail mutations dispatch a `deckchange`
  *      CustomEvent on the element: detail = {action, from, to, slide}.
+ *
+ * Present-skip — a section authored with `data-deck-present-skip` is hopped
+ * over by prev/next navigation *only while presenting* (standalone
+ * fullscreen, or a host posting __omelette_presenting). Off-stage it stays a
+ * normal, navigable slide carrying a "Skipped" watermark, and it prints to
+ * PDF like any other slide. Use it to drop a slide from one delivery (e.g. a
+ * shorter conference slot) without removing it from the deck or the handout.
  *
  * Slides are HIDDEN, not unmounted. Non-active slides stay in the DOM with
  * `visibility: hidden` + `opacity: 0`, so their state (videos, iframes,
@@ -189,6 +195,33 @@
       pointer-events: auto;
       transform: translate(-50%, 0) scale(1);
       filter: blur(0);
+    }
+
+    /* Present-skip watermark — drawn over the stage region (left offset set
+       by _fit to clear the rail) when the active slide is data-deck-present-
+       skip and we're NOT presenting. Hidden in presenting (the slide is
+       hopped over so it can't be active) and in print (@media print below),
+       so the PDF handout stays clean. */
+    .skipwm {
+      position: fixed;
+      inset: 0;
+      display: none;
+      align-items: center;
+      justify-content: center;
+      pointer-events: none;
+      user-select: none;
+      z-index: 2147482000;
+    }
+    :host([data-deck-present-skip-active]) .skipwm { display: flex; }
+    .skipwm span {
+      font: 800 150px/1 ui-sans-serif, system-ui, -apple-system, sans-serif;
+      letter-spacing: 0.1em;
+      text-transform: uppercase;
+      color: rgba(217, 119, 87, 0.22);
+      border: 8px solid rgba(217, 119, 87, 0.32);
+      border-radius: 22px;
+      padding: 0.12em 0.34em;
+      transform: rotate(-16deg);
     }
 
     .btn {
@@ -532,17 +565,14 @@
         break-inside: avoid;
         overflow: hidden;
       }
-      /* :last-child alone isn't enough once data-deck-skip hides the
-         trailing slide(s) — the last *visible* slide still carries
-         break-after:page and prints a blank sheet. _markLastVisible()
-         maintains data-deck-last-visible on the last non-skipped slide. */
-      ::slotted(*:last-child),
-      ::slotted([data-deck-last-visible]) {
+      /* Last slide drops its break-after so no trailing blank sheet prints.
+         Every slide prints (present-skip included), so :last-child is the
+         genuine final page — no skip-aware bookkeeping needed. */
+      ::slotted(*:last-child) {
         break-after: auto;
         page-break-after: auto;
       }
-      ::slotted([data-deck-skip]) { display: none !important; }
-      .overlay, .tapzones, .rail, .rail-resize, .ctxmenu, .confirm-backdrop { display: none !important; }
+      .overlay, .tapzones, .rail, .rail-resize, .ctxmenu, .confirm-backdrop, .skipwm { display: none !important; }
     }
   `;
 
@@ -893,6 +923,16 @@
       overlay.querySelector('.next').addEventListener('click', () => this._advance(1, 'click'));
       overlay.querySelector('.reset').addEventListener('click', () => this._go(0, 'click'));
 
+      // Present-skip watermark (see .skipwm CSS). Toggled by _applyIndex /
+      // _syncPresenting via the host's data-deck-present-skip-active attr.
+      // NOT export-hidden: it's a live-review marker that should survive
+      // screenshots; only the PDF strips it, via the @media print rule.
+      const skipwm = document.createElement('div');
+      skipwm.className = 'skipwm';
+      skipwm.setAttribute('data-omelette-chrome', '');
+      skipwm.setAttribute('aria-hidden', 'true');
+      skipwm.innerHTML = '<span>Skipped</span>';
+
       // Thumbnail rail + context menu. Thumbnails are populated in
       // _renderRail() after _collectSlides().
       const rail = document.createElement('div');
@@ -917,7 +957,6 @@
       menu.className = 'ctxmenu export-hidden';
       menu.setAttribute('data-omelette-chrome', '');
       menu.innerHTML = `
-        <button type="button" data-act="skip">Skip slide</button>
         <button type="button" data-act="up">Move up</button>
         <button type="button" data-act="down">Move down</button>
         <hr>
@@ -928,8 +967,7 @@
         if (!act) return;
         const i = this._menuIndex;
         this._closeMenu();
-        if (act === 'skip') this._toggleSkip(i);
-        else if (act === 'up') this._moveSlide(i, i - 1);
+        if (act === 'up') this._moveSlide(i, i - 1);
         else if (act === 'down') this._moveSlide(i, i + 1);
         else if (act === 'delete') this._openConfirm(i);
       });
@@ -983,10 +1021,11 @@
         this._deleteSlide(i);
       });
 
-      this._root.append(style, rail, resize, stage, tapzones, overlay, menu, confirm);
+      this._root.append(style, rail, resize, stage, tapzones, overlay, skipwm, menu, confirm);
       this._canvas = canvas;
       this._slot = slot;
       this._overlay = overlay;
+      this._skipwm = skipwm;
       this._tapzones = tapzones;
       this._rail = rail;
       this._resize = resize;
@@ -1073,20 +1112,7 @@
 
       if (this._totalEl) this._totalEl.textContent = String(this._slides.length || 1);
       if (this._index >= this._slides.length) this._index = Math.max(0, this._slides.length - 1);
-      this._markLastVisible();
       this._renderRail();
-    }
-
-    /** Tag the last non-skipped slide so print CSS can drop its
-     *  break-after (see the @media print comment above — :last-child
-     *  alone matches a hidden skipped slide). */
-    _markLastVisible() {
-      let last = null;
-      this._slides.forEach((s) => {
-        s.removeAttribute('data-deck-last-visible');
-        if (!s.hasAttribute('data-deck-skip')) last = s;
-      });
-      if (last) last.setAttribute('data-deck-last-visible', '');
     }
 
     _loadNotes() {
@@ -1132,6 +1158,13 @@
       const currSlide = this._slides[curr];
       if (prevSlide && prevSlide.hasAttribute('data-step-max')) prevSlide.setAttribute('data-step', '0');
       if (currSlide && currSlide.hasAttribute('data-step-max')) currSlide.setAttribute('data-step', '0');
+      // Present-skip watermark: on only when the active slide is a present-
+      // skip slide and we're off-stage. While presenting it's hopped over so
+      // it can never be active; the !presenting guard just covers the
+      // enter-fullscreen-while-sitting-on-it transition (handled in
+      // _syncPresenting before this runs).
+      this.toggleAttribute('data-deck-present-skip-active',
+        !this._presenting && !!currSlide && currSlide.hasAttribute('data-deck-present-skip'));
       if (this._countEl) this._countEl.textContent = String(curr + 1);
       // Follow-scroll on every navigation (init deep-link, keyboard, click,
       // tap, external goTo) — the only time we *don't* want the rail to
@@ -1201,15 +1234,18 @@
         if (stage) stage.style.left = '0';
         if (this._overlay) this._overlay.style.marginLeft = '0';
         if (this._tapzones) this._tapzones.style.left = '0';
+        if (this._skipwm) this._skipwm.style.left = '0';
         return;
       }
       const rw = this._railWidth();
       if (stage) stage.style.left = rw + 'px';
       // Overlay is centred on the viewport via left:50% + translate(-50%);
       // marginLeft shifts the centre by rw/2 so it lands in the middle of
-      // the [rw, innerWidth] stage region. Tapzones just inset from rw.
+      // the [rw, innerWidth] stage region. Tapzones just inset from rw, and
+      // the present-skip watermark covers the same stage region.
       if (this._overlay) this._overlay.style.marginLeft = (rw / 2) + 'px';
       if (this._tapzones) this._tapzones.style.left = rw + 'px';
+      if (this._skipwm) this._skipwm.style.left = rw + 'px';
       const vw = window.innerWidth - rw;
       const vh = window.innerHeight;
       const s = Math.min(vw / this.designWidth, vh / this.designHeight);
@@ -1286,6 +1322,27 @@
         this._overlay.removeAttribute('data-visible');
         if (this._hideTimer) clearTimeout(this._hideTimer);
       }
+      // Entering presenting while sitting on a present-skip slide: hop to the
+      // nearest live slide (forward first, then back) so it never reaches the
+      // audience. _go → _applyIndex also clears the watermark attr.
+      if (presenting) {
+        const cur = this._slides[this._index];
+        if (cur && cur.hasAttribute('data-deck-present-skip')) {
+          const live = (start, dir) => {
+            let j = start;
+            while (j >= 0 && j < this._slides.length &&
+                   this._slides[j].hasAttribute('data-deck-present-skip')) j += dir;
+            return (j >= 0 && j < this._slides.length) ? j : -1;
+          };
+          let j = live(this._index + 1, 1);
+          if (j < 0) j = live(this._index - 1, -1);
+          if (j >= 0) this._go(j, 'api');
+        }
+      }
+      // Presenting flips watermark visibility for whatever slide is current.
+      const cur2 = this._slides[this._index];
+      this.toggleAttribute('data-deck-present-skip-active',
+        !this._presenting && !!cur2 && cur2.hasAttribute('data-deck-present-skip'));
       this._syncRailHidden();
       this._closeMenu();
       this._closeConfirm();
@@ -1446,13 +1503,15 @@
       }
     }
 
-    /** Step forward/back skipping any slide marked data-deck-skip. Falls
-     *  back to _go's clamp-at-ends behaviour (flash overlay) when there's
-     *  nothing further in that direction. */
+    /** Step forward/back, hopping data-deck-present-skip slides *only while
+     *  presenting* — off-stage they're normal navigable slides. Falls back to
+     *  _go's clamp-at-ends behaviour (flash overlay) when there's nothing
+     *  further in that direction. */
     _advance(dir, reason) {
       if (!this._slides.length) return;
       let i = this._index + dir;
-      while (i >= 0 && i < this._slides.length && this._slides[i].hasAttribute('data-deck-skip')) {
+      while (i >= 0 && i < this._slides.length &&
+             this._presenting && this._slides[i].hasAttribute('data-deck-present-skip')) {
         i += dir;
       }
       if (i < 0 || i >= this._slides.length) { this._flashOverlay(); return; }
@@ -1505,7 +1564,7 @@
         if (at !== want) this._rail.insertBefore(want, at || null);
         t.i = i;
         t.num.textContent = String(i + 1);
-        if (t.slide.hasAttribute('data-deck-skip')) t.thumb.setAttribute('data-skip', '');
+        if (t.slide.hasAttribute('data-deck-present-skip')) t.thumb.setAttribute('data-skip', '');
         else t.thumb.removeAttribute('data-skip');
       });
       this._thumbs = next;
@@ -1791,9 +1850,6 @@
     _openMenu(i, x, y) {
       if (!this._menu) return;
       this._menuIndex = i;
-      const slide = this._slides[i];
-      const skip = slide && slide.hasAttribute('data-deck-skip');
-      this._menu.querySelector('[data-act="skip"]').textContent = skip ? 'Unskip slide' : 'Skip slide';
       this._menu.querySelector('[data-act="up"]').disabled = i <= 0;
       this._menu.querySelector('[data-act="down"]').disabled = i >= this._slides.length - 1;
       this._menu.querySelector('[data-act="delete"]').disabled = this._slides.length <= 1;
@@ -1845,27 +1901,13 @@
       this._applyIndex({ showOverlay: true, broadcast: true, reason: 'mutation' });
     }
 
-    _toggleSkip(i) {
-      const slide = this._slides[i];
-      if (!slide) return;
-      const on = !slide.hasAttribute('data-deck-skip');
-      if (on) slide.setAttribute('data-deck-skip', '');
-      else slide.removeAttribute('data-deck-skip');
-      if (this._thumbs && this._thumbs[i]) {
-        if (on) this._thumbs[i].thumb.setAttribute('data-skip', '');
-        else this._thumbs[i].thumb.removeAttribute('data-skip');
-      }
-      this._markLastVisible();
-      this._emitDeckChange({ action: on ? 'skip' : 'unskip', from: i, slide });
-      // Re-broadcast so the presenter popup's prev/next thumbnails re-pick
-      // the nearest non-skipped slide without waiting for a nav event.
-      try { window.postMessage({ slideIndexChanged: this._index, deckTotal: this._slides.length, deckSkipped: this._skippedIndices() }, '*'); } catch (e) {}
-    }
-
+    /** Indices of present-skip slides — the ones the live talk hops over.
+     *  Broadcast as `deckSkipped` so a presenter popup can re-pick the
+     *  nearest live slide for its prev/next thumbnails. */
     _skippedIndices() {
       const out = [];
       for (let i = 0; i < this._slides.length; i++) {
-        if (this._slides[i].hasAttribute('data-deck-skip')) out.push(i);
+        if (this._slides[i].hasAttribute('data-deck-present-skip')) out.push(i);
       }
       return out;
     }

--- a/static/presentations/2026-devtalks-romania/index.html
+++ b/static/presentations/2026-devtalks-romania/index.html
@@ -3064,7 +3064,7 @@
          tier 4 — Helm Java KindContainer (Testcontainers + KinD)
                   HelmKubernetesTest · ~50 s startup (CI log)
        ============================================================ -->
-  <section class="s-feedback-ladder light" data-label="Act V · Fast feedback loops: the agent must learn quickly" data-step-max="1">
+  <section class="s-feedback-ladder light" data-label="Act V · Fast feedback loops: the agent must learn quickly" data-step-max="1" data-deck-present-skip>
     <div class="chrome-top">
       <span class="dot"></span>
       <span>~/dev/devtalks-2026 · devtalks-act-05-codebase-feedback/FeedbackLoops.md</span>

--- a/tests/deck-kit/contract.spec.js
+++ b/tests/deck-kit/contract.spec.js
@@ -15,12 +15,12 @@ const IMAGE_SLOT_ATTRS = ['shape', 'radius', 'mask', 'fit', 'position', 'placeho
 const DECK_STAGE_ATTRS = ['width', 'height', 'noscale', 'no-rail'];
 // `<section>` data-* attributes that deck-stage reads from consumer markup.
 // data-step is runtime state managed by deck-stage; data-step-max and
-// data-deck-skip are author-set; data-label is author-set.
-const SECTION_DATA_ATTRS = ['data-label', 'data-deck-skip', 'data-step-max', 'data-step'];
+// data-deck-present-skip are author-set; data-label is author-set.
+const SECTION_DATA_ATTRS = ['data-label', 'data-deck-present-skip', 'data-step-max', 'data-step'];
 const SLIDECHANGE_DETAIL_KEYS = ['index', 'previousIndex', 'total', 'slide', 'previousSlide', 'reason'];
 const SLIDECHANGE_REASONS = ['init', 'keyboard', 'click', 'tap', 'api', 'mutation'];
 const DECKCHANGE_DETAIL_KEYS = ['action', 'from', 'to', 'slide'];
-const DECKCHANGE_ACTIONS = ['delete', 'skip', 'unskip', 'move'];
+const DECKCHANGE_ACTIONS = ['delete', 'move'];
 const DECK_STAGE_API = ['index', 'length', 'goTo', 'next', 'prev', 'reset'];
 
 describe('deck-kit contract — append-only', () => {
@@ -124,12 +124,9 @@ describe('deck-kit contract — append-only', () => {
       const stage = document.querySelector('deck-stage');
       const events = [];
       stage.addEventListener('deckchange', (e) => events.push(e.detail));
-      // _moveSlide / _toggleSkip / _deleteSlide are the rail-UI canonical
-      // entry points. Fire all four documented actions so removing any
-      // one would be caught.
+      // _moveSlide / _deleteSlide are the rail-UI canonical entry points.
+      // Fire both documented actions so removing either would be caught.
       stage._moveSlide(0, 1);
-      stage._toggleSkip(0);
-      stage._toggleSkip(0);
       stage._deleteSlide(stage._slides.length - 1);
       return events.map((d) => ({ keys: Object.keys(d), action: d.action }));
     });
@@ -306,17 +303,35 @@ describe('deck-kit contract — append-only', () => {
     await page.close();
   });
 
-  // ── data-deck-skip ────────────────────────────────────────────────────
-  // Per the contract, a section flagged data-deck-skip is excluded from
-  // keyboard advance. Duplicate of deck-stage-rail.spec.js by design —
-  // dropping skip support must fail in the contract suite too.
-  test('data-deck-skip excludes a section from keyboard navigation', async () => {
+  // ── data-deck-present-skip ────────────────────────────────────────────
+  // Per the contract, a section flagged data-deck-present-skip is hopped
+  // over by keyboard advance ONLY while presenting; off-stage it stays a
+  // normal navigable slide. Duplicate of deck-stage-rail.spec.js by design —
+  // dropping present-skip support must fail in the contract suite too.
+  test('data-deck-present-skip is navigable off-stage, hopped while presenting', async () => {
     const page = await browser.newPage();
     await bootDeck(page, server.fixture('minimal-deck-skip.html'));
-    await page.keyboard.press('ArrowRight');
-    await page.keyboard.press('ArrowRight'); // hops over the skipped section
-    const idx = await page.evaluate(() => document.querySelector('deck-stage').index);
-    assert.notEqual(idx, 2, 'index 2 is data-deck-skip and must not be reached by keyboard nav');
+    // Off-stage: present-skip slide (index 2) is reachable by keyboard.
+    await page.keyboard.press('ArrowRight'); // 0 → 1
+    await page.keyboard.press('ArrowRight'); // 1 → 2 (lands on it)
+    assert.equal(
+      await page.evaluate(() => document.querySelector('deck-stage').index), 2,
+      'present-skip slide must be navigable when not presenting',
+    );
+    // Enter presenting via the omelette source (no real fullscreen needed),
+    // reset to 0, then advance: nav now hops over index 2.
+    await page.evaluate(() => {
+      const s = document.querySelector('deck-stage');
+      s.reset();
+      s._omelettePresenting = true;
+      s._syncPresenting();
+    });
+    await page.keyboard.press('ArrowRight'); // 0 → 1
+    await page.keyboard.press('ArrowRight'); // 1 → 3 (hops 2)
+    assert.equal(
+      await page.evaluate(() => document.querySelector('deck-stage').index), 3,
+      'present-skip slide must be hopped over while presenting',
+    );
     await page.close();
   });
 
@@ -468,7 +483,7 @@ describe('deck-kit contract — append-only', () => {
   test('SECTION_DATA_ATTRS matches the README-documented surface', () => {
     assert.deepEqual(
       [...SECTION_DATA_ATTRS].sort(),
-      ['data-deck-skip', 'data-label', 'data-step', 'data-step-max'],
+      ['data-deck-present-skip', 'data-label', 'data-step', 'data-step-max'],
     );
   });
 });

--- a/tests/deck-kit/deck-stage-print.spec.js
+++ b/tests/deck-kit/deck-stage-print.spec.js
@@ -41,8 +41,9 @@ describe('deck-stage print layout', () => {
       const slides = document.querySelectorAll('deck-stage > section');
       return Array.from(slides).map((s) => getComputedStyle(s).breakAfter);
     });
-    // First N-1 should be 'page'; the last (or [data-deck-last-visible])
-    // should be 'auto' to avoid a trailing blank sheet.
+    // First N-1 should be 'page'; the last should be 'auto' to avoid a
+    // trailing blank sheet. Every slide prints, so :last-child is the
+    // genuine final page.
     for (let i = 0; i < breakAfter.length - 1; i++) {
       assert.equal(breakAfter[i], 'page', `slide ${i} should break-after: page`);
     }
@@ -50,24 +51,26 @@ describe('deck-stage print layout', () => {
     await page.close();
   });
 
-  test('data-deck-skip slides are display:none under print media', async () => {
+  test('data-deck-present-skip slides still print (not display:none)', async () => {
     const page = await withPrintMedia('minimal-deck-skip.html');
     const display = await page.evaluate(() => {
-      const skipped = document.querySelector('deck-stage > section[data-deck-skip]');
-      return getComputedStyle(skipped).display;
+      const ps = document.querySelector('deck-stage > section[data-deck-present-skip]');
+      return getComputedStyle(ps).display;
     });
-    assert.equal(display, 'none');
+    // Present-skip drops a slide from live nav, not from the deck — it must
+    // still paginate into the PDF handout.
+    assert.notEqual(display, 'none');
     await page.close();
   });
 
-  test('print PDF emits one page per non-skipped slide', async () => {
+  test('print PDF emits one page per slide (present-skip slides included)', async () => {
     const page = await withPrintMedia('minimal-deck-skip.html');
-    // 5 sections, 1 skipped → expect 4 pages.
+    // 5 sections, 1 present-skip → all 5 print.
     const pdf = await page.pdf({ format: 'A4', printBackground: false });
     // Count "/Type /Page" entries in the PDF stream (rough but reliable).
     const text = pdf.toString('latin1');
     const matches = text.match(/\/Type\s*\/Page[^s]/g) || [];
-    assert.equal(matches.length, 4, `expected 4 pages, got ${matches.length}`);
+    assert.equal(matches.length, 5, `expected 5 pages, got ${matches.length}`);
     await page.close();
   });
 

--- a/tests/deck-kit/deck-stage-rail.spec.js
+++ b/tests/deck-kit/deck-stage-rail.spec.js
@@ -43,10 +43,16 @@ describe('deck-stage thumbnail rail', () => {
     await page.close();
   });
 
-  test('data-deck-skip excludes a slide from keyboard nav', async () => {
+  test('data-deck-present-skip excludes a slide from keyboard nav while presenting', async () => {
     const page = await browser.newPage();
     await bootDeck(page, server.fixture('minimal-deck-skip.html'));
-    // Slides: 0, 1, 2(skip), 3, 4. ArrowRight from 1 should land on 3, not 2.
+    // Drive presenting via the omelette source (no real fullscreen in headless).
+    await page.evaluate(() => {
+      const s = document.querySelector('deck-stage');
+      s._omelettePresenting = true;
+      s._syncPresenting();
+    });
+    // Slides: 0, 1, 2(present-skip), 3, 4. ArrowRight from 1 lands on 3, not 2.
     await page.keyboard.press('ArrowRight'); // 0 → 1
     assert.equal(await page.evaluate(() => document.querySelector('deck-stage').index), 1);
     await page.keyboard.press('ArrowRight'); // 1 → 3 (skipping 2)
@@ -56,7 +62,7 @@ describe('deck-stage thumbnail rail', () => {
     await page.close();
   });
 
-  test('data-deck-skip thumb gets data-skip in the rail', async () => {
+  test('data-deck-present-skip thumb gets data-skip in the rail', async () => {
     const page = await browser.newPage();
     await bootDeck(page, server.fixture('minimal-deck-skip.html'));
     const skipped = await page.evaluate(() => {
@@ -64,7 +70,7 @@ describe('deck-stage thumbnail rail', () => {
       const thumbs = stage.shadowRoot.querySelectorAll('.rail .thumb');
       return Array.from(thumbs).map((t) => t.hasAttribute('data-skip'));
     });
-    // Slide indices: 0, 1, 2(skip), 3, 4 → expect [false, false, true, false, false]
+    // Slide indices: 0, 1, 2(present-skip), 3, 4 → expect [false, false, true, false, false]
     assert.deepEqual(skipped, [false, false, true, false, false]);
     await page.close();
   });

--- a/tests/deck-kit/fixtures/minimal-deck-skip.html
+++ b/tests/deck-kit/fixtures/minimal-deck-skip.html
@@ -9,7 +9,7 @@
 <deck-stage width="1920" height="1080">
   <section data-label="Zero"><h1>0</h1></section>
   <section data-label="One"><h1>1</h1></section>
-  <section data-label="Two (skipped)" data-deck-skip><h1>skip</h1></section>
+  <section data-label="Two (present-skip)" data-deck-present-skip><h1>skip</h1></section>
   <section data-label="Three"><h1>3</h1></section>
   <section data-label="Four"><h1>4</h1></section>
 </deck-stage>


### PR DESCRIPTION
## What

Adds `data-deck-present-skip`, a first-class deck-kit section attribute for
**per-venue slide cuts** on talks repeated under different time budgets.

A section flagged `data-deck-present-skip`:

- is **hopped over by prev/next navigation only while presenting** (standalone
  fullscreen, or a host posting `__omelette_presenting`);
- off stage stays a **normal, navigable slide** carrying a translucent
  "Skipped" watermark — rendered by deck-kit, and not `export-hidden`, so it
  survives review screenshots;
- still **prints to the PDF cleanly** (watermark hidden via `@media print`),
  so the handout is unaffected.

Entering fullscreen while sitting on such a slide auto-hops to the nearest
live slide so it never reaches the audience.

## Why

The DevTalks Romania deck is repeated at other venues (Valencia JUG, …) with
different slot lengths. This lets a slide be dropped from one delivery without
removing it from the deck or the PDF — toggle the attribute per venue. Applied
to the Act V "Fast feedback loops" slide, cut from the 45-min Romania slot.

## Removed

Replaces the upstream Claude-Design ephemeral rail right-click "Skip slide"
toggle, which only this deck used: `_toggleSkip`, the `skip`/`unskip`
`deckchange` actions, `data-deck-skip`, the print `display:none` rule, and
`_markLastVisible`/`data-deck-last-visible`. Rail Move/Delete are unchanged.

## Contract + tests

Append-only deck-kit contract updated to match (README section attrs;
`deckchange` actions now `{delete, move}`). `contract.spec.js`,
`deck-stage-print.spec.js`, `deck-stage-rail.spec.js` and the
`minimal-deck-skip.html` fixture swapped to present-skip semantics.
**67/67 deck-kit tests pass** (`npm run test:deck-kit`).

## Verification

- On-screen: watermark renders on the feedback slide; neighbouring slides clean.
- PDF: `export:pdf` emits all 48 pages; the feedback slide prints with no watermark.