### PR TITLE
💄 devtalks-2026: rebuild the project-story slide as a 3-step reveal

### DIFF
--- a/static/presentations/2026-devtalks-romania/index.html
+++ b/static/presentations/2026-devtalks-romania/index.html
@@ -2826,8 +2826,8 @@
          - quarkus-resteasy-reactive → quarkus-rest (artifact rename)
          - Test imports switched from Fabric8's KubernetesServer to
            the Quarkus test wrapper
-         - −123 lines of legacy API fallback code deleted
-           (extensions/v1beta1 Ingress + batch/v1beta1 CronJob)
+         - −119 lines of legacy API fallback code deleted
+           (extensions/v1beta1 Ingress −80 + batch/v1beta1 CronJob −39)
          - 10 IT @Test methods across 3 Selenium-driven *IT.java
            files (HomeIT, PodLogsIT, PodExecIT) as the safety net
 
@@ -2837,12 +2837,22 @@
        in the speaker's voice (Marc's lived experience) — it is
        not asserted by any on-slide artifact.
 
-       Two-step reveal:
-         step 0  PR card + grunt-work panel highlighted; contract
-                 panel slightly muted so the speaker can land the
-                 "no new feature · low dopamine" beat first.
-         step 1  Contract panel lights up; takeaway tagline appears
-                 in the footer.
+       Three-step reveal (data-step-max="2") — a real tension →
+       safety-net → payoff build, not a brightness toggle:
+         step 0  TENSION. PR card + grunt-work panel only. The
+                 safety-net panel is a ghost frame (header +
+                 "// already in the repo" label show, body hidden)
+                 so the payoff is NOT spoiled. Left foot carries the
+                 "i handed all of this to Claude" attribution.
+         step 1  GUARDRAILS. The safety-net panel materialises and
+                 the compiler|tests duality goes legible — the left
+                 foot flips to "the compiler caught the renames"
+                 (accent), the right foot carries "the tests pinned
+                 the behavior" (green). The two guardrails = the two
+                 panels. The Σ payoff stamp stays hidden.
+         step 2  PAYOFF. Green halo + the "zero assertion changes"
+                 Σ stamp land; the takeaway tagline shows BOTH claims
+                 (the contract held + put the net up first).
 
        Silhouette choice: wide GitHub-style PR card across the top
        + two stacked panels below. Looks like a GitHub PR review
@@ -2852,21 +2862,26 @@
        Speaker framing (held in eyebrow + sub + foot lines):
          - "one of many recent agent-assisted PRs" → eyebrow.
            Anti-highlight-reel framing.
-         - "no new feature · low dopamine · agent territory" →
-           sub. The grunt-task framing the audience is meant to
-           recognize in themselves.
-         - "i handed this to Claude." → left-panel foot. First
-           person, no overclaim.
-         - "when these pass, the upgrade is done." → right-panel
-           foot. The IT contract is the spec.
-         - "The agent took the grunt work. The tests defined done."
-           → footer tagline (step 1 reveal).
+         - "tedious maintenance · agent territory" → sub. The
+           grunt-task framing the audience recognises in itself.
+         - compiler vs tests duality: Java's strong typing kills API
+           hallucination (the compiler refuses a rename until it is
+           real — left foot); the black-box assertions preserve
+           behavior (right foot + Σ stamp). Two guardrails, two jobs.
+         - "i handed all of this to Claude." → step-0 left foot.
+           First person, no overclaim (the PR is signed by Marc).
+         - "Zero assertion changes. The assertions didn't move." → the
+           Σ payoff. Only the import coordinates moved (compiler-
+           forced, trivially reviewable); the behavior contract held.
+         - "The contract held. Put the net up first, then delegate."
+           → footer tagline (step-2 reveal). Proof + the lesson:
+           stand up the black-box net BEFORE delegating grunt work.
 
        Clickable references (PDF-friendly):
          - PR card (overlay) → github.com/manusa/yakd/pull/172
          - inline #146, #149 → respective issues
        ============================================================ -->
-  <section class="s-project-story light" data-label="Act V · Real project story: black-box tests unlock large changes" data-step-max="1">
+  <section class="s-project-story light" data-label="Act V · Real project story: black-box tests unlock large changes" data-step-max="2">
     <div class="chrome-top">
       <span class="dot"></span>
       <span>~/dev/devtalks-2026 · devtalks-act-05-codebase-feedback/ProjectStory.md</span>
@@ -2880,7 +2895,8 @@
         <div class="eyebrow">// act 05 · one of many recent agent-assisted PRs</div>
         <h2 class="title">Black-box tests unlocked a <em>large change</em>.</h2>
         <p class="sub">
-          <span class="t-warn">tedious maintenance</span> · agent territory
+          <span class="t-warn">tedious maintenance</span><br>
+          agent territory
         </p>
       </header>
 
@@ -2947,15 +2963,17 @@
               <span class="sp-row-note mono">artifact rename</span>
             </li>
             <li class="sp-row sp-row-delta">
-              <span class="sp-row-key mono"><span class="diff-rem">−123</span></span>
+              <span class="sp-row-key mono"><span class="diff-rem">−119</span></span>
               <span class="sp-row-val mono">legacy API fallback</span>
               <span class="sp-row-note mono">v1beta1 Ingress · CronJob</span>
             </li>
           </ul>
           <footer class="sp-foot mono">
-            <div class="foot-line">// the <span class="t-guard">compiler</span> steered the renames</div>
-            <div class="foot-line">// the <span class="t-guard">tests</span> steered the behavior</div>
-            <div class="foot-line">// i handed it all to <span class="t-claude">Claude</span>.</div>
+            <div class="foot-state foot-state-0">// I handed all of this to <span class="t-claude">Claude</span></div>
+            <div class="foot-state foot-state-1">
+              <div class="foot-line foot-key">the <span class="t-guard">compiler</span> caught the renames</div>
+              <div class="foot-line foot-sub">strongly typed · no hallucinated API</div>
+            </div>
           </footer>
         </article>
 
@@ -2976,13 +2994,10 @@
         <article class="story-panel contract-panel">
           <header class="sp-head">
             <span class="sp-glyph">▣</span>
-            <span class="sp-label">The test portfolio</span>
+            <span class="sp-label">The safety net</span>
             <span class="sp-tag mono">// already in the repo</span>
           </header>
           <div class="portfolio">
-            <div class="portfolio-headline">
-              Black-box coverage <span class="port-soft">across the full stack</span>
-            </div>
             <ul class="portfolio-chips">
               <li class="port-chip">
                 <span class="chip-name mono">REST Assured</span>
@@ -2990,26 +3005,27 @@
               </li>
               <li class="port-chip">
                 <span class="chip-name mono">Selenium IT</span>
-                <span class="chip-intent mono">UI → backend → K8s</span>
+                <span class="chip-intent mono">full UI flow</span>
               </li>
               <li class="port-chip">
                 <span class="chip-name mono">Quarkus infra</span>
-                <span class="chip-intent mono">WebSocket · watchers</span>
+                <span class="chip-intent mono">live WebSocket</span>
               </li>
             </ul>
             <div class="portfolio-connector mono">
-              // all use <span class="t-conn">@QuarkusTest · @WithKubernetesTestServer</span>
+              real HTTP · <span class="t-conn">a real K8s test API server</span> · not mocks
             </div>
             <div class="portfolio-sigma">
               <span class="sigma-glyph">✓</span>
               <div class="sigma-text">
                 <span class="sigma-label">Zero assertion changes.</span>
-                <span class="sigma-soft mono">The tests didn't move.</span>
+                <span class="sigma-soft mono">Same behavior, 19 versions later.</span>
               </div>
             </div>
           </div>
           <footer class="sp-foot mono">
-            // when these pass, the upgrade is <span class="t-done">done</span>.
+            <div class="foot-line foot-key">the <span class="t-done">tests</span> pinned the behavior</div>
+            <div class="foot-line foot-sub">// when these pass, the upgrade is done</div>
           </footer>
         </article>
       </div>
@@ -3017,6 +3033,9 @@
       <footer class="tag-line">
         <div class="quote">
           The <span class="accent">contract</span> held.
+        </div>
+        <div class="lesson">
+          Put the <span class="accent">net</span> up first, then delegate.
         </div>
       </footer>
     </div>

--- a/static/presentations/2026-devtalks-romania/styles/s-project-story.css
+++ b/static/presentations/2026-devtalks-romania/styles/s-project-story.css
@@ -74,8 +74,8 @@
 }
 .s-project-story .head .title {
   grid-column: 1;
-  font-size: 60px;
-  line-height: 1.06;
+  font-size: 68px;
+  line-height: 1.04;
   letter-spacing: -0.02em;
   font-weight: 700;
   margin: 0;
@@ -144,7 +144,7 @@
   font-weight: 500;
 }
 .s-project-story .pr-status {
-  font-size: 19px;
+  font-size: 21px;
   letter-spacing: 0.10em;
   text-transform: uppercase;
   padding: 2px 10px;
@@ -343,7 +343,22 @@
   line-height: 1.4;
 }
 .s-project-story .sp-foot .foot-line { display: block; }
-.s-project-story .sp-foot .foot-line + .foot-line { margin-top: 2px; }
+.s-project-story .sp-foot .foot-line + .foot-line { margin-top: 3px; }
+.s-project-story .sp-foot { transition: opacity 260ms ease; }
+/* The duality lines (compiler caught the renames · tests pinned the
+   behavior) are the thesis — promote them off the old 22px floor to a
+   must-read size; the // sub-lines stay a quieter qualifier tier. */
+.s-project-story .sp-foot .foot-key {
+  font-size: 28px;
+  font-weight: 600;
+  color: var(--fg);
+  letter-spacing: -0.005em;
+}
+.s-project-story .sp-foot .foot-sub {
+  font-size: 22px;
+  color: var(--fg-mute);
+}
+.s-project-story .sp-foot .foot-state-0 { font-size: 24px; }
 .s-project-story .t-claude {
   color: var(--accent-2-ink, var(--accent-2));
   font-weight: 700;
@@ -361,31 +376,18 @@
    Portfolio body — replaces the old .sp-list table on the
    contract panel. The grunt-work panel still uses .sp-list.
 
-   Hierarchy (top → bottom):
-     headline     Black-box coverage across the full stack
+   Hierarchy (top → bottom), revealed across the 3-step build:
      chips        3 intent chips (REST Assured · Selenium IT · Quarkus infra)
-     connector    // all use @QuarkusTest + @WithKubernetesTestServer
-     sigma block  big 0  ·  assertion changes across the upgrade
+     connector    // real HTTP · a real K8s test API server · not mocks
+     sigma block  ✓ zero assertion changes (gated to step 2)
    ============================================================ */
 .s-project-story .portfolio {
   display: flex;
   flex-direction: column;
-  padding: 18px 18px 12px;
+  padding: 16px 18px 12px;
   flex: 1 1 auto;
   min-height: 0;
-  gap: 14px;
-}
-.s-project-story .portfolio-headline {
-  font-family: 'JetBrains Mono', monospace;
-  font-size: 26px;
-  font-weight: 600;
-  color: var(--fg);
-  letter-spacing: -0.005em;
-  line-height: 1.22;
-}
-.s-project-story .port-soft {
-  color: var(--fg-mute);
-  font-weight: 500;
+  gap: 12px;
 }
 .s-project-story .portfolio-chips {
   list-style: none;
@@ -400,7 +402,7 @@
   align-items: baseline;
   justify-content: space-between;
   gap: 14px;
-  padding: 9px 14px;
+  padding: 8px 14px;
   background: rgba(255, 255, 255, 0.55);
   border: 1px solid rgba(10, 21, 84, 0.16);
   border-radius: 8px;
@@ -419,7 +421,7 @@
   white-space: nowrap;
 }
 .s-project-story .portfolio-connector {
-  font-size: 22px;
+  font-size: 26px;
   color: var(--fg-mute);
   letter-spacing: 0.02em;
   padding-left: 2px;
@@ -438,17 +440,18 @@
    never do alone. Mnemonic shape (✓) > mnemonic count (0). */
 .s-project-story .portfolio-sigma {
   margin-top: auto;
-  padding: 16px 22px;
+  margin-bottom: 10px;
+  padding: 13px 20px;
   background: rgba(var(--ok-rgb), 0.12);
   border-radius: 10px;
   border: 1px solid rgba(var(--ok-rgb), 0.45);
   box-shadow: inset 5px 0 0 rgba(var(--ok-rgb), 0.90);
   display: flex;
   align-items: center;
-  gap: 18px;
+  gap: 16px;
 }
 .s-project-story .sigma-glyph {
-  font-size: 44px;
+  font-size: 40px;
   font-weight: 700;
   color: var(--ok);
   line-height: 1;
@@ -475,32 +478,67 @@
 }
 
 /* ============================================================
-   Step-driven highlighting.
-   Step 0: contract panel is muted (the speaker holds attention
-           on the grunt-work side).
-   Step 1: contract panel takes a green halo and full color.
+   Step-driven reveal — a real 3-beat build.
+     step 0  TENSION. Only the PR card + grunt-work panel carry
+             weight. The safety-net panel is a ghost frame: its
+             header/label show ("// already in the repo") but the
+             body + foot are hidden, so the payoff is NOT spoiled.
+             Left foot shows the attribution line.
+     step 1  GUARDRAILS. The safety-net panel materialises and the
+             compiler|tests duality goes legible — the left foot
+             flips to the compiler line (accent), the right foot
+             carries the tests line (green). The Σ stamp stays hidden.
+     step 2  PAYOFF. Green halo + the "zero assertion changes" stamp
+             land, and the takeaway tagline (both claims) appears.
    ============================================================ */
-.s-project-story[data-step="0"] .contract-panel {
-  opacity: 0.55;
-  filter: saturate(0.65);
+
+/* Left foot crossfades attribution (step 0) → compiler guardrail (1+). */
+.s-project-story .work-panel .foot-state-1 { display: none; }
+.s-project-story[data-step="1"] .work-panel .foot-state-0,
+.s-project-story[data-step="2"] .work-panel .foot-state-0 { display: none; }
+.s-project-story[data-step="1"] .work-panel .foot-state-1,
+.s-project-story[data-step="2"] .work-panel .foot-state-1 { display: block; }
+
+/* Smooth fades for the revealed regions. */
+.s-project-story .contract-panel .portfolio,
+.s-project-story .contract-panel .portfolio-sigma {
+  transition: opacity 260ms ease;
 }
-.s-project-story[data-step="1"] .contract-panel {
-  opacity: 1;
-  filter: none;
+
+/* Step 0 — safety-net panel is a ghost: header only, dashed + faint. */
+.s-project-story[data-step="0"] .contract-panel {
+  background: rgba(255, 255, 255, 0.28);
+  border-style: dashed;
+  box-shadow: none;
+}
+.s-project-story[data-step="0"] .contract-panel .portfolio,
+.s-project-story[data-step="0"] .contract-panel .sp-foot {
+  opacity: 0;
+  visibility: hidden;
+}
+
+/* The Σ payoff stamp keeps its layout slot but stays hidden until step 2. */
+.s-project-story:not([data-step="2"]) .contract-panel .portfolio-sigma {
+  opacity: 0;
+  visibility: hidden;
+}
+
+/* Step 2 — the green "contract held" payoff. */
+.s-project-story[data-step="2"] .contract-panel {
   border-color: rgba(var(--ok-rgb), 0.50);
   box-shadow:
     0 0 0 1px rgba(var(--ok-rgb), 0.32),
     0 16px 36px rgba(var(--ok-rgb), 0.14),
     0 2px 8px rgba(var(--ok-rgb), 0.08);
 }
-.s-project-story[data-step="1"] .contract-panel .sp-head {
+.s-project-story[data-step="2"] .contract-panel .sp-head {
   background: rgba(var(--ok-rgb), 0.08);
   border-bottom-color: rgba(var(--ok-rgb), 0.25);
 }
-.s-project-story[data-step="1"] .contract-panel .sp-glyph {
+.s-project-story[data-step="2"] .contract-panel .sp-glyph {
   color: var(--ok);
 }
-.s-project-story[data-step="1"] .contract-panel .sp-foot {
+.s-project-story[data-step="2"] .contract-panel .sp-foot {
   background: linear-gradient(
     to bottom,
     rgba(var(--ok-rgb), 0.10),
@@ -523,19 +561,33 @@
   transition: opacity 280ms ease;
   pointer-events: none;
 }
-.s-project-story[data-step="1"] .tag-line {
+.s-project-story[data-step="2"] .tag-line {
   opacity: 1;
   pointer-events: auto;
 }
 .s-project-story .tag-line .quote {
-  font-size: 30px;
-  font-weight: 600;
+  font-size: 32px;
+  font-weight: 700;
   line-height: 1.2;
   color: var(--fg);
   letter-spacing: -0.005em;
   text-wrap: balance;
 }
 .s-project-story .tag-line .quote .accent {
+  color: var(--accent);
+}
+/* The prescriptive lesson — the imperative that turns the slide from
+   "it worked" into "here's the rule". Mono, a quieter tier than the
+   proof line above it, so the two claims read as proof → lesson. */
+.s-project-story .tag-line .lesson {
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 26px;
+  font-weight: 600;
+  line-height: 1.2;
+  color: var(--fg-dim);
+  letter-spacing: 0.01em;
+}
+.s-project-story .tag-line .lesson .accent {
   color: var(--accent);
 }
 
@@ -548,9 +600,21 @@
   .s-project-story .story-panel {
     box-shadow: none;
   }
+  /* Flatten the step reveal to its final (step-2) state so the PDF
+     handout shows the whole story: net materialised, Σ stamp landed,
+     compiler line and takeaway visible. */
   .s-project-story .contract-panel {
     opacity: 1 !important;
     filter: none !important;
+    border-style: solid !important;
   }
+  .s-project-story .contract-panel .portfolio,
+  .s-project-story .contract-panel .sp-foot,
+  .s-project-story .contract-panel .portfolio-sigma {
+    opacity: 1 !important;
+    visibility: visible !important;
+  }
+  .s-project-story .work-panel .foot-state-0 { display: none !important; }
+  .s-project-story .work-panel .foot-state-1 { display: block !important; }
   .s-project-story .tag-line { opacity: 1 !important; }
 }


### PR DESCRIPTION
## What

Rebuilds the Act V "Black-box tests unlocked a large change" slide (`s-project-story`, the YAKD PR #172 story) from a flat two-step into a real three-step reveal.

## Why

The slide had two steps but no real reveal — at step 0 the contract panel was already on screen (only dimmed), so the "zero assertion changes" payoff was readable before the speaker said a word, and the compiler-vs-tests thesis was buried in 22px footer text.

## Changes

- **3-step build**: tension (the change + a ghost safety-net frame) → guardrails (the net materialises; the compiler/tests duality reads across the two aligned footers) → payoff (green halo + the "zero assertion changes" stamp + the takeaway).
- **Takeaway lands both proof and lesson**: "The contract held." + "Put the net up first, then delegate."
- **Accuracy**: −123 → −119 legacy lines (Ingress −80 + CronJob −39); "the tests didn't move" → "zero assertion changes / same behavior, 19 versions later".
- **Credibility**: surfaced "real HTTP · a real K8s test API server · not mocks".
- **Legibility**: title to one line at 68px, the compiler/tests thesis promoted off the 22px floor to 28px, status pill 19→21px, dropped a redundant headline.

Verified: 0 fit-audit overflow across all three steps; the rest of the deck is pixel-identical (snapshot diff).