### PR TITLE
💄 devtalks-2026: rebuild the leverage slide as a 3-step reveal

### DIFF
--- a/static/presentations/2026-devtalks-romania/index.html
+++ b/static/presentations/2026-devtalks-romania/index.html
@@ -1895,18 +1895,34 @@
   <!-- ============================================================
        13 ACT 4 · SHAPE THE WORK UPSTREAM
 
-       The calm slide — the exhale after three dense ones. Expensive
-       reasoning once → cheap execution N times. Artifact: helm-java
-       #351 (OPEN · good first issue), short because the recipe was
-       already extracted into AGENTS.md + a named reference impl
-       (StatusCommand). Also the cost/token beat: think expensively
-       once, run cheaply N times.
+       The calm slide — the exhale after three dense ones. Its own
+       logic is a 3-node chain (expensive reasoning → the spec it
+       produces → cheap execution N times), staged as a real 3-step
+       build rather than a brightness toggle. Artifact: helm-java #351
+       (OPEN · good first issue), surfaced with its concrete fluent
+       contract so "the expensive thinking" is shown, not asserted.
 
-       Step 0 — equation + issue collapsed to title + labels.
-       Step 1 — issue body reveals (acceptance · Java-8 · ref impl);
-                the "anyone can run it" channels light up.
+       Three-step reveal (data-step-max="2"):
+         step 0  TENSION. Header + the expensive band only. The issue
+                 is a collapsed frame: GitHub bar + title + labels show,
+                 the body is not yet rendered, so the spec is not
+                 spoiled. The flow-arrow and cheap band are absent too.
+                 Sparse and calm by design.
+         step 1  REVEAL. The flow-arrow ("produces a detailed spec")
+                 and the issue body appear together — the real
+                 Helm.rollback(...) contract, the nested-k8s-test
+                 validation, the StatusCommand reference impl. The
+                 thinking on the left produced THIS spec on the right.
+         step 2  PAYOFF. The cheap × N band lands (smaller model ·
+                 contributor · future-you), the "good first issue"
+                 label halos in sync (the punchline made literal:
+                 anyone can run it), and the takeaway lands as a proof
+                 line + a prescriptive lesson.
+
+       Clickable reference (PDF-friendly):
+         - issue card #351 → github.com/manusa/helm-java/issues/351
        ============================================================ -->
-  <section class="s-leverage light" data-label="Act IV · Shape the work upstream" data-step-max="1">
+  <section class="s-leverage light" data-label="Act IV · Shape the work upstream" data-step-max="2">
     <div class="chrome-top">
       <span class="dot"></span>
       <span>~/dev/devtalks-2026 · manusa/helm-java/issues/351</span>
@@ -1917,18 +1933,20 @@
     <div class="body">
       <i class="pillar-watermark road-watermark fa-solid fa-road" aria-hidden="true"></i>
       <header class="head">
-        <div class="eyebrow">// act 04 · leverage</div>
         <h2 class="title">Shape the work <em>upstream</em>.</h2>
         <p class="sub">
-          Use your best reasoning to shape the work,<br/>
-          not just to <em>write the code</em>.
+          Reason once, where it's <em>expensive</em>.<br/>
+          Implement many times, where it's <em>cheap</em>.
         </p>
       </header>
 
       <div class="stage">
         <!-- ============================================================
              Principle (left): spend the expensive model once →
-             cheap implementation N times. Cheap half reveals on step 1.
+             cheap implementation N times.
+               step 0  expensive band only
+               step 1  flow-arrow reveals (the spec it produces)
+               step 2  cheap band reveals (who runs it, N times)
              ============================================================ -->
         <div class="principle">
           <div class="band expensive">
@@ -1939,7 +1957,7 @@
             <div class="work">understand the change · explore the codebase<br/>surface edge cases<br/>define acceptance criteria · propose the tests</div>
           </div>
 
-          <div class="flow-arrow"><span class="arr">↓</span> produces a detailed spec</div>
+          <div class="flow-arrow"><span class="arr">↓</span><span class="arr-text">produces a detailed spec</span></div>
 
           <div class="band cheap">
             <div class="brow">
@@ -1952,14 +1970,15 @@
               <li><i class="fa-solid fa-clock-rotate-left"></i>future-you</li>
             </ul>
           </div>
-
-          <div class="spec-hint">↳ a <b>spec-driven workflow</b>: formalize it with a framework, or keep it free-form.</div>
         </div>
 
         <!-- ============================================================
-             Artifact (right): the real, DETAILED helm-java #351.
-             Compatibility + Validation = where the expensive thinking
-             went, so a cheap executor can run it safely.
+             Artifact (right): the real helm-java #351. The body (the
+             concrete spec) is the step-1 reveal; the header (it exists,
+             it's open, it's a good first issue) anchors step 0.
+               Contract     the real fluent API the issue proposes
+               Validation   nested k8s tests + the module test command
+               meta         Java-8 constraint + the reference impl
              ============================================================ -->
         <article class="issue">
           <header class="panel-bar gh">
@@ -1979,29 +1998,28 @@
             </div>
           </div>
           <div class="issue-body">
-            <div class="block">
-              <div class="bh">Compatibility</div>
-              <div class="ln"><span class="hot">Java 8 baseline</span> · no var, no records</div>
-              <div class="ln">additive public API only</div>
-              <div class="ln">preserve existing behavior</div>
+            <div class="block contract">
+              <div class="bh">Contract</div>
+              <pre class="api"><code><span class="k">Helm</span>.<span class="m">rollback</span>(<span class="s">"r"</span>)
+    .<span class="m">toRevision</span>(n).<span class="m">call</span>() <span class="ret">→ Release</span></code></pre>
             </div>
             <div class="block">
               <div class="bh">Validation</div>
-              <div class="ln">add a JUnit regression test</div>
-              <div class="ln">run <code>./mvnw test -pl helm-java</code></div>
-              <div class="ln">don't hand-edit generated native code</div>
+              <div class="ln">nested k8s tests in <code>HelmKubernetesTest</code></div>
+              <div class="ln"><code>./mvnw test -pl helm-java</code></div>
             </div>
-            <div class="ref">reference impl → <code>StatusCommand.java</code></div>
+            <div class="meta">
+              <span class="m-java">Java 8 · no var, no records</span>
+              <span class="m-ref">reference impl → <code>StatusCommand.java</code></span>
+            </div>
           </div>
         </article>
       </div>
 
       <div class="tag-line">
         <span class="lbl">// takeaway</span>
-        <div class="quotes">
-          <span class="quote q-0">Spend the expensive model on the <em>problem</em>, not the typing.</span>
-          <span class="quote q-1">Cheap implementation is possible when the problem was <em>expensive to think through</em>.</span>
-        </div>
+        <div class="proof"><em>Anyone</em> can pick this up now.</div>
+        <div class="lesson">Do the expensive thinking <b>once</b>, so the rest stays cheap.</div>
       </div>
     </div>
 

--- a/static/presentations/2026-devtalks-romania/index.html
+++ b/static/presentations/2026-devtalks-romania/index.html
@@ -1963,7 +1963,7 @@
             </ul>
           </div>
 
-          <div class="flow-arrow"><span class="arr">↓</span> produces a detailed spec</div>
+          <div class="flow-arrow"><span class="arr">↓</span> produces a <em>detailed spec</em></div>
 
           <div class="band cheap">
             <div class="brow">

--- a/static/presentations/2026-devtalks-romania/index.html
+++ b/static/presentations/2026-devtalks-romania/index.html
@@ -1954,10 +1954,16 @@
               <span class="cost"><span class="amt">$$$</span><span class="lbl">think once</span></span>
               <span class="bhead"><i class="fa-solid fa-brain"></i>strongest model, upstream</span>
             </div>
-            <div class="work">understand the change · explore the codebase<br/>surface edge cases<br/>define acceptance criteria · propose the tests</div>
+            <ul class="work">
+              <li>understand the change</li>
+              <li>explore the codebase</li>
+              <li>surface edge cases</li>
+              <li>define acceptance criteria</li>
+              <li>propose the tests</li>
+            </ul>
           </div>
 
-          <div class="flow-arrow"><span class="arr">↓</span><span class="arr-text">produces a detailed spec</span></div>
+          <div class="flow-arrow"><span class="arr">↓</span> produces a detailed spec</div>
 
           <div class="band cheap">
             <div class="brow">

--- a/static/presentations/2026-devtalks-romania/styles/s-leverage.css
+++ b/static/presentations/2026-devtalks-romania/styles/s-leverage.css
@@ -231,6 +231,9 @@
   animation: lev-reveal 300ms cubic-bezier(.2, .7, .2, 1) both;
 }
 .s-leverage .flow-arrow .arr { color: var(--accent-ink); font-weight: 700; font-size: 32px; }
+/* "detailed spec" is the noun the whole slide turns on — accent it with
+   the deck's standard emphasis idiom (same as .sub em / .proof em). */
+.s-leverage .flow-arrow em { font-style: normal; color: var(--accent-ink); font-weight: 600; }
 
 /* ---------- Artifact (right): the detailed helm-java #351 issue ---------- */
 .s-leverage .issue {

--- a/static/presentations/2026-devtalks-romania/styles/s-leverage.css
+++ b/static/presentations/2026-devtalks-romania/styles/s-leverage.css
@@ -162,11 +162,31 @@
 }
 .s-leverage .band.expensive .bhead i { color: var(--accent-2-ink); margin-right: 6px; }
 
+/* The expensive-work list: one task per line with a consistent accent
+   marker, so the items read as a uniform set (no mixed `·` / line-break
+   grouping). Mono, kept at the 28px must-read size. */
 .s-leverage .band .work {
+  list-style: none;
+  margin: 0;
+  padding: 0;
   font-family: 'JetBrains Mono', monospace;
   font-size: 28px;
-  line-height: 1.5;
+  line-height: 1.32;
   color: var(--fg-dim);
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+.s-leverage .band .work li {
+  display: flex;
+  align-items: baseline;
+  gap: 12px;
+}
+.s-leverage .band .work li::before {
+  content: "·";
+  color: var(--accent-2-ink);
+  font-weight: 700;
+  flex-shrink: 0;
 }
 .s-leverage .band .implementers {
   list-style: none;
@@ -195,7 +215,7 @@
 /* connector between the two bands — the step-1 reveal that links the
    expensive thinking to the spec it produces (the issue, on the right). */
 .s-leverage .flow-arrow {
-  display: flex;
+  display: none;
   align-items: center;
   gap: 14px;
   padding-left: 8px;
@@ -203,17 +223,14 @@
   color: var(--fg-dim);
   font-size: 28px;
 }
-.s-leverage .flow-arrow .arr { color: var(--accent-ink); font-weight: 700; font-size: 32px; }
-/* Step 0: a faint downward stub under the expensive band, no label — it
-   promises the chain continues, so the calm lower half reads as "to be
-   continued", not "unfinished". */
-.s-leverage[data-step="0"] .flow-arrow { opacity: 0.32; }
-.s-leverage[data-step="0"] .flow-arrow .arr-text { display: none; }
-/* Step 1: the connector completes (the label appears) as the spec lands. */
+/* The flow-arrow is the step-1 reveal that links the expensive thinking
+   to the spec it produces — it is absent at step 0, not a faint stub. */
 .s-leverage[data-step="1"] .flow-arrow,
 .s-leverage[data-step="2"] .flow-arrow {
+  display: flex;
   animation: lev-reveal 300ms cubic-bezier(.2, .7, .2, 1) both;
 }
+.s-leverage .flow-arrow .arr { color: var(--accent-ink); font-weight: 700; font-size: 32px; }
 
 /* ---------- Artifact (right): the detailed helm-java #351 issue ---------- */
 .s-leverage .issue {
@@ -458,7 +475,6 @@
     animation: none !important;
     opacity: 1 !important;
   }
-  .s-leverage .flow-arrow .arr-text { display: inline !important; }
   .s-leverage .issue .issue-body {
     display: flex !important;
     animation: none !important;

--- a/static/presentations/2026-devtalks-romania/styles/s-leverage.css
+++ b/static/presentations/2026-devtalks-romania/styles/s-leverage.css
@@ -2,27 +2,33 @@
    .s-leverage — Act 4, slide 13.
    "Shape the work upstream."
 
-   The economics of delegation, made concrete:
+   The economics of delegation, staged as a real 3-step build
+   (data-step-max="2") instead of a brightness toggle. The slide's
+   own logic is a 3-node chain and each beat is one keypress:
 
-     PRINCIPLE (left) — spend your strongest, most EXPENSIVE model
-       once, upstream: understand, explore, surface edge cases,
-       acceptance criteria, tests. That produces a detailed spec.
-       Then implementation is CHEAP and runs N times — a smaller
-       model, an external contributor, or future-you.
+     step 0  TENSION. Header + the EXPENSIVE band only (spend your
+       strongest model once, upstream: understand, explore, edge
+       cases, acceptance criteria, tests). The issue is a collapsed
+       frame: GitHub bar + title + labels show; the body is not yet
+       rendered, so the spec is not spoiled. The flow-arrow and the
+       cheap band are absent too. Calm, sparse, lots of room.
 
-     ARTIFACT (right) — a real, DETAILED issue (helm-java #351,
-       "good first issue") with Compatibility + Validation blocks.
-       Detailed on purpose: that is where the expensive thinking
-       went, so a cheap executor can run it safely.
+     step 1  REVEAL. The flow-arrow ("produces a detailed spec") and
+       the issue BODY appear together — the real Helm.rollback(...)
+       contract, the nested-k8s-test validation, the StatusCommand
+       reference impl. The thinking on the left produced THIS spec.
 
-   Step 0 — the expensive upstream half + the detailed issue.
-   Step 1 — the cheap-execution half lights up (smaller model ·
-            contributor · future-you), the takeaway lands.
+     step 2  PAYOFF. The CHEAP × N band lands (smaller model ·
+       contributor · future-you), the "good first issue" label halos
+       in sync (the punchline made literal: anyone can run it), and
+       the takeaway lands as a proof line + a prescriptive lesson.
 
-   A lightweight spec-driven workflow; the slide hints at going
-   deeper. Content lifted off the 7-9pt floor for projection
-   (FONT-AUDIT slide 17): principle bands 22-28px, GitHub-issue
-   artifact 18-22px. Width already reclaimed (64px chrome-bar gutter).
+   Legibility: staging the content across steps is what buys the room
+   to clear the projection floors (px ÷ 2 = pt on a 1080px canvas;
+   must-read ≥ 28px, mono the speaker reads ≥ 28px). Only one or two
+   regions compete per step, so the must-read tier sits at 28-36px;
+   the decorative chrome (eyebrow, pill, breadcrumb, // labels) stays
+   at the 20-24px deck-wide convention.
    ============================================================ */
 
 /* Faint dotted grid — atmosphere only, same idiom as siblings */
@@ -34,6 +40,12 @@
   background-size: 44px 44px;
   pointer-events: none;
   z-index: 0;
+}
+
+/* Shared reveal: content fades up into place as each step lands. */
+@keyframes lev-reveal {
+  from { opacity: 0; transform: translateY(8px); }
+  to   { opacity: 1; transform: translateY(0); }
 }
 
 /* ============================================================
@@ -58,19 +70,10 @@
   align-items: center;
   column-gap: 48px;
 }
-.s-leverage .head .eyebrow {
-  grid-column: 1;
-  font-family: 'JetBrains Mono', monospace;
-  font-size: 20px;
-  letter-spacing: 0.18em;
-  text-transform: lowercase;
-  color: var(--accent-ink);
-  margin-bottom: 14px;
-}
 .s-leverage .head .title {
   grid-column: 1;
-  font-size: 64px;
-  line-height: 1.06;
+  font-size: 72px;
+  line-height: 1.04;
   letter-spacing: -0.02em;
   font-weight: 700;
   margin: 0;
@@ -84,7 +87,7 @@
   grid-column: 2;
   margin: 0;
   font-family: 'JetBrains Mono', monospace;
-  font-size: 24px;
+  font-size: 28px;
   line-height: 1.45;
   color: var(--fg-dim);
   text-align: right;
@@ -92,7 +95,9 @@
 .s-leverage .head .sub em { font-style: normal; color: var(--accent-ink); font-weight: 600; }
 
 /* ============================================================
-   Stage — principle (left) + artifact (right)
+   Stage — principle (left) + artifact (right).
+   Top-aligned so revealed regions grow DOWN into the slack at the
+   bottom of the band; existing content never reflows or jumps.
    ============================================================ */
 .s-leverage .stage {
   position: relative;
@@ -100,66 +105,66 @@
   grid-template-columns: minmax(0, 1fr) minmax(0, 1.02fr);
   column-gap: 52px;
   align-items: start;       /* both columns share a top edge */
-  align-content: center;    /* …and the pair centers in the stage band */
+  align-content: start;     /* the pair hugs the top; reveals fill below */
 }
 
 /* ---------- Principle (left): expensive → cheap ---------- */
 .s-leverage .principle {
   display: flex;
   flex-direction: column;
-  gap: 12px;
+  gap: 14px;
 }
 .s-leverage .band {
   background: #FFFFFF;
   border: 1px solid #D1D9E0;
   border-radius: 10px;
-  padding: 18px 22px;
+  padding: 20px 24px;
   box-shadow: 0 8px 20px rgba(10, 21, 84, 0.08);
 }
 .s-leverage .band.expensive { border-left: 4px solid var(--accent-2); }
+
+/* The cheap band is the payoff: absent until step 2, then it fades in. */
 .s-leverage .band.cheap {
+  display: none;
   border-left: 4px solid var(--cyan-ink);
-  opacity: 0.42;                       /* dim but legible until the reveal */
-  transition:
-    opacity 400ms cubic-bezier(.2, .7, .2, 1),
-    background 400ms cubic-bezier(.2, .7, .2, 1);
-}
-.s-leverage[data-step="1"] .band.cheap {
-  opacity: 1;
   background: linear-gradient(90deg, rgba(8, 105, 120, 0.06), #FFFFFF 60%);
+}
+.s-leverage[data-step="2"] .band.cheap {
+  display: block;
+  animation: lev-reveal 340ms cubic-bezier(.2, .7, .2, 1) both;
 }
 
 .s-leverage .band .brow {
   display: flex;
   align-items: baseline;
-  gap: 12px;
-  margin-bottom: 10px;
+  gap: 14px;
+  margin-bottom: 12px;
 }
 .s-leverage .band .cost {
   display: inline-flex;
   align-items: baseline;
-  gap: 7px;
+  gap: 8px;
   font-family: 'JetBrains Mono', monospace;
   flex-shrink: 0;
 }
-.s-leverage .band .cost .amt { font-size: 26px; font-weight: 700; letter-spacing: -0.01em; }
-.s-leverage .band .cost .lbl { font-size: 20px; font-weight: 600; letter-spacing: 0.1em; text-transform: uppercase; }
-.s-leverage .band.expensive .cost .amt { color: var(--accent-2-ink); font-size: 28px; }
+.s-leverage .band .cost .amt { font-size: 30px; font-weight: 700; letter-spacing: -0.01em; }
+.s-leverage .band .cost .lbl { font-size: 26px; font-weight: 600; letter-spacing: 0.08em; text-transform: uppercase; }
+.s-leverage .band.expensive .cost .amt { color: var(--accent-2-ink); font-size: 32px; }
 .s-leverage .band.expensive .cost .lbl { color: var(--accent-2-ink); }
 .s-leverage .band.cheap .cost .amt { color: var(--cyan-ink); }
 .s-leverage .band.cheap .cost .lbl { color: var(--cyan-ink); }
 .s-leverage .band .bhead {
   font-family: 'Inter', system-ui, sans-serif;
-  font-size: 24px;
+  font-size: 30px;
   font-weight: 700;
   letter-spacing: -0.01em;
   color: var(--fg);
 }
-.s-leverage .band.expensive .bhead i { color: var(--accent-2-ink); margin-right: 4px; }
+.s-leverage .band.expensive .bhead i { color: var(--accent-2-ink); margin-right: 6px; }
 
 .s-leverage .band .work {
   font-family: 'JetBrains Mono', monospace;
-  font-size: 22px;
+  font-size: 28px;
   line-height: 1.5;
   color: var(--fg-dim);
 }
@@ -169,45 +174,46 @@
   padding: 0;
   display: flex;
   flex-direction: column;
-  gap: 7px;
+  gap: 9px;
 }
 .s-leverage .band .implementers li {
   display: flex;
   align-items: center;
-  gap: 12px;
+  gap: 14px;
   font-family: 'Inter', system-ui, sans-serif;
-  font-size: 22px;
+  font-size: 28px;
   color: var(--fg);
 }
 .s-leverage .band .implementers li i {
   color: var(--cyan-ink);
-  width: 26px;
+  width: 30px;
   text-align: center;
-  font-size: 20px;
+  font-size: 24px;
   flex-shrink: 0;
 }
 
-/* connector between the two bands */
+/* connector between the two bands — the step-1 reveal that links the
+   expensive thinking to the spec it produces (the issue, on the right). */
 .s-leverage .flow-arrow {
   display: flex;
   align-items: center;
-  gap: 12px;
+  gap: 14px;
   padding-left: 8px;
   font-family: 'JetBrains Mono', monospace;
   color: var(--fg-dim);
-  font-size: 22px;
+  font-size: 28px;
 }
-.s-leverage .flow-arrow .arr { color: var(--accent-ink); font-weight: 700; font-size: 26px; }
-
-/* spec-driven hint */
-.s-leverage .spec-hint {
-  margin-top: 4px;
-  font-family: 'JetBrains Mono', monospace;
-  font-size: 22px;
-  line-height: 1.45;
-  color: var(--fg-mute);
+.s-leverage .flow-arrow .arr { color: var(--accent-ink); font-weight: 700; font-size: 32px; }
+/* Step 0: a faint downward stub under the expensive band, no label — it
+   promises the chain continues, so the calm lower half reads as "to be
+   continued", not "unfinished". */
+.s-leverage[data-step="0"] .flow-arrow { opacity: 0.32; }
+.s-leverage[data-step="0"] .flow-arrow .arr-text { display: none; }
+/* Step 1: the connector completes (the label appears) as the spec lands. */
+.s-leverage[data-step="1"] .flow-arrow,
+.s-leverage[data-step="2"] .flow-arrow {
+  animation: lev-reveal 300ms cubic-bezier(.2, .7, .2, 1) both;
 }
-.s-leverage .spec-hint b { color: var(--fg-dim); font-weight: 600; }
 
 /* ---------- Artifact (right): the detailed helm-java #351 issue ---------- */
 .s-leverage .issue {
@@ -226,89 +232,129 @@
   display: flex;
   align-items: center;
   gap: 10px;
-  padding: 13px 20px;
+  padding: 14px 22px;
   background: #F6F8FA;
   border-bottom: 1px solid #D1D9E0;
   font-family: 'JetBrains Mono', monospace;
-  font-size: 18px;
-  letter-spacing: 0.02em;
+  font-size: 24px;
+  letter-spacing: 0.01em;
   color: #59636E;
 }
-.s-leverage .issue .panel-bar.gh .gh-icon { color: #1F2328; font-size: 20px; }
+.s-leverage .issue .panel-bar.gh .gh-icon { color: #1F2328; font-size: 26px; }
 .s-leverage .issue .panel-bar.gh .repo { color: #1F2328; font-weight: 600; }
 .s-leverage .issue .panel-bar.gh .sep { color: #59636E; }
 .s-leverage .issue .panel-bar.gh .num { color: #59636E; text-decoration: none; }
 .s-leverage .issue .panel-bar.gh .num:hover { color: #0969DA; text-decoration: underline; }
 .s-leverage .issue .panel-bar.gh .grow { flex: 1; }
 .s-leverage .issue .panel-bar.gh .status.open {
-  font-size: 18px;
+  font-size: 24px;
   font-weight: 600;
-  padding: 4px 12px;
+  padding: 4px 14px;
   border-radius: 999px;
   color: #FFFFFF;
   background: #1F883D;
   border: 1px solid #1A7F37;
   display: inline-flex;
   align-items: center;
-  gap: 6px;
+  gap: 7px;
 }
 .s-leverage .issue .panel-bar.gh .status.open::before {
   content: "";
-  width: 8px; height: 8px; border-radius: 50%;
+  width: 9px; height: 9px; border-radius: 50%;
   background: #FFFFFF;
 }
 
 .s-leverage .issue .issue-head {
-  padding: 16px 24px 14px;
+  padding: 18px 24px 16px;
   display: flex;
   flex-direction: column;
-  gap: 12px;
+  gap: 14px;
   font-family: 'Inter', system-ui, sans-serif;
   color: #1F2328;
   border-bottom: 1px solid #E4E7EC;
 }
 .s-leverage .issue .issue-title {
   margin: 0;
-  font-size: 24px;
-  line-height: 1.3;
+  font-size: 34px;
+  line-height: 1.25;
   font-weight: 600;
-  letter-spacing: -0.005em;
+  letter-spacing: -0.01em;
   color: #1F2328;
 }
-.s-leverage .issue .labels { display: flex; flex-wrap: wrap; gap: 8px; }
+.s-leverage .issue .labels { display: flex; flex-wrap: wrap; gap: 10px; }
 .s-leverage .issue .labels .lab {
   font-family: 'JetBrains Mono', monospace;
-  font-size: 18px;
+  font-size: 24px;
   font-weight: 600;
-  padding: 3px 12px;
+  padding: 4px 14px;
   border-radius: 999px;
-  line-height: 1.4;
+  line-height: 1.35;
 }
 .s-leverage .issue .labels .lab.enhancement { background: #A2EEEF; color: #044E54; }
 .s-leverage .issue .labels .lab.help        { background: #008672; color: #FFFFFF; }
 .s-leverage .issue .labels .lab.gfi         { background: #7057FF; color: #FFFFFF; }
+/* PAYOFF: "help wanted" + "good first issue" are the punchline made
+   literal. They do not appear until step 2, landing in sync with the
+   cheap-execution band: the spec is complete enough that this work is
+   now anyone's to pick up. (One row of pills either way, so revealing
+   them never reflows the head or the body below it.) */
+.s-leverage .issue .labels .lab.help,
+.s-leverage .issue .labels .lab.gfi { display: none; }
+.s-leverage[data-step="2"] .issue .labels .lab.help,
+.s-leverage[data-step="2"] .issue .labels .lab.gfi {
+  display: inline-block;
+  animation: lev-reveal 320ms cubic-bezier(.2, .7, .2, 1) both;
+}
 
+/* The issue BODY is the step-1 reveal: the concrete spec. Absent at
+   step 0 (the collapsed issue), it appears with the flow-arrow. */
 .s-leverage .issue .issue-body {
-  padding: 18px 24px 20px;
+  display: none;
+  padding: 20px 24px 22px;
   font-family: 'JetBrains Mono', monospace;
-  font-size: 22px;
-  line-height: 1.5;
+  font-size: 28px;
+  line-height: 1.45;
   color: #1F2328;
-  display: flex;
   flex-direction: column;
-  gap: 14px;
+  gap: 16px;
+}
+.s-leverage[data-step="1"] .issue .issue-body,
+.s-leverage[data-step="2"] .issue .issue-body {
+  display: flex;
+  animation: lev-reveal 320ms cubic-bezier(.2, .7, .2, 1) both;
 }
 .s-leverage .issue .block .bh {
   font-weight: 700;
   color: #0550AE;
-  margin-bottom: 4px;
+  margin-bottom: 6px;
 }
+
+/* Contract block — the real fluent API. This is the single line that
+   turns "trust me, I thought about it" into a verifiable spec. */
+.s-leverage .issue .block.contract .api {
+  margin: 0;
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 28px;
+  line-height: 1.45;
+  color: #1F2328;
+  background: #F6F8FA;
+  border: 1px solid #E4E7EC;
+  border-radius: 8px;
+  padding: 12px 16px;
+  white-space: pre;
+}
+.s-leverage .issue .api .k { color: #1F2328; font-weight: 700; }
+.s-leverage .issue .api .m { color: #6F42C1; }
+.s-leverage .issue .api .s { color: #0A3069; }
+.s-leverage .issue .api .ret { color: #59636E; }
+
 .s-leverage .issue .block .ln {
   display: flex;
   align-items: baseline;
-  gap: 10px;
+  gap: 12px;
   color: #1F2328;
 }
+.s-leverage .issue .block .ln + .ln { margin-top: 6px; }
 .s-leverage .issue .block .ln::before {
   content: "−";
   color: #6E7781;
@@ -319,38 +365,51 @@
   background: rgba(130, 80, 223, 0.08);
   border: 1px solid rgba(130, 80, 223, 0.20);
   border-radius: 4px;
-  padding: 0 6px;
+  padding: 0 7px;
   font-family: 'JetBrains Mono', monospace;
-  font-size: 20px;
+  font-size: 28px;
 }
-.s-leverage .issue .block .ln .hot {
-  color: #A04707;
-  font-weight: 600;
-}
-.s-leverage .issue .ref {
+
+/* meta footer — the constraint + the reference impl, the two facts
+   that make the spec runnable by a cheap executor. */
+.s-leverage .issue .meta {
   border-top: 1px dashed #D1D9E0;
-  padding-top: 12px;
-  font-size: 20px;
+  padding-top: 14px;
+  margin-top: 2px;
+  display: flex;
+  flex-direction: column;
+  gap: 7px;
+  font-size: 24px;
   color: #59636E;
 }
-.s-leverage .issue .ref code {
+.s-leverage .issue .meta .m-java { color: #A04707; font-weight: 600; }
+.s-leverage .issue .meta code {
   color: #6F42C1;
   background: rgba(130, 80, 223, 0.08);
   border: 1px solid rgba(130, 80, 223, 0.20);
   border-radius: 4px;
-  padding: 0 6px;
-  font-size: 18px;
+  padding: 0 7px;
+  font-size: 24px;
 }
 
 /* ============================================================
-   Tag line — morphs between step 0 (principle) and step 1 (payoff)
+   Tag line — the payoff (proof + lesson), revealed only at step 2.
+   Slot is reserved (visibility, not display) so the stage band height
+   never changes between steps.
    ============================================================ */
 .s-leverage .tag-line {
   position: relative;
   display: flex;
   flex-direction: column;
   gap: 6px;
-  min-height: 56px;
+  min-height: 118px;
+  opacity: 0;
+  visibility: hidden;
+  transition: opacity 340ms cubic-bezier(.2, .7, .2, 1);
+}
+.s-leverage[data-step="2"] .tag-line {
+  opacity: 1;
+  visibility: visible;
 }
 .s-leverage .tag-line .lbl {
   font-family: 'JetBrains Mono', monospace;
@@ -359,37 +418,65 @@
   text-transform: uppercase;
   color: var(--fg-mute);
 }
-.s-leverage .tag-line .quotes {
-  position: relative;
-  min-height: 40px;
-}
-.s-leverage .tag-line .quote {
-  font-size: 32px;
-  font-weight: 600;
+/* Proof — what just happened, on screen (the artifact backs it up). */
+.s-leverage .tag-line .proof {
+  font-size: 36px;
+  font-weight: 700;
   line-height: 1.2;
   color: var(--fg);
   letter-spacing: -0.005em;
   text-wrap: balance;
-  transition: opacity 350ms cubic-bezier(.2, .7, .2, 1);
 }
-.s-leverage .tag-line .quote em {
+.s-leverage .tag-line .proof em {
   font-style: normal;
   color: var(--accent-ink);
 }
-.s-leverage .tag-line .quote.q-1 {
-  position: absolute;
-  inset: 0;
-  opacity: 0;
+/* Lesson — the prescriptive imperative, a quieter mono tier. */
+.s-leverage .tag-line .lesson {
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 28px;
+  font-weight: 600;
+  line-height: 1.25;
+  color: var(--fg-dim);
+  letter-spacing: 0.005em;
 }
-.s-leverage[data-step="1"] .tag-line .quote.q-0 { opacity: 0; }
-.s-leverage[data-step="1"] .tag-line .quote.q-1 { opacity: 1; }
+.s-leverage .tag-line .lesson b {
+  color: var(--accent-ink);
+  font-weight: 700;
+}
 
 /* ============================================================
-   Print — drop heavy shadows for PDF export; both steps render,
-   so the cheap band must be legible (force opacity up in print).
+   Print — flatten the step reveal to its final (step-2) state so the
+   PDF handout shows the whole story: arrow + issue body + cheap band
+   + takeaway all visible, the good-first-issue payoff landed.
    ============================================================ */
 @media print {
   .s-leverage .issue,
   .s-leverage .band { box-shadow: none; border-color: #B8C2CC; }
-  .s-leverage .band.cheap { opacity: 1; }
+  .s-leverage .flow-arrow {
+    display: flex !important;
+    animation: none !important;
+    opacity: 1 !important;
+  }
+  .s-leverage .flow-arrow .arr-text { display: inline !important; }
+  .s-leverage .issue .issue-body {
+    display: flex !important;
+    animation: none !important;
+    opacity: 1 !important;
+  }
+  .s-leverage .band.cheap {
+    display: block !important;
+    animation: none !important;
+    opacity: 1 !important;
+  }
+  .s-leverage .tag-line {
+    opacity: 1 !important;
+    visibility: visible !important;
+  }
+  .s-leverage .issue .labels .lab.help,
+  .s-leverage .issue .labels .lab.gfi {
+    display: inline-block !important;
+    animation: none !important;
+    opacity: 1 !important;
+  }
 }


### PR DESCRIPTION
## Summary

Slide 13 / section 17 "Shape the work upstream" (`.s-leverage`) was a fake 2-step "brightness toggle": at step 0 the whole slide was already on screen (the cheap "× N" band only dimmed to `opacity: 0.42`, the helm-java #351 panel fully shown) and step 1 only brightened the band and swapped one near-identical takeaway quote. Neither keypress added information, and most content sat below the projection legibility floors (43 runs under 28px, smallest 9pt).

Rebuilt as a real 3-step build (`data-step-max="2"`), tension → reveal → payoff:

- **step 0 — tension:** header + the expensive `$$$ think once` band; the issue is a collapsed frame (GitHub bar + title + only the `enhancement` label). A faint `↓` stub promises the chain continues.
- **step 1 — reveal:** the flow-arrow completes ("produces a detailed spec") and the issue body materialises — the real `Helm.rollback("r").toRevision(n).call() → Release` contract, nested-k8s-test validation, and the `StatusCommand` reference impl.
- **step 2 — payoff:** the cheap `¢ × N` band lands (smaller model / external contributor / future-you), `help wanted` + `good first issue` appear in sync (the punchline made literal: anyone can pick it up), and the takeaway lands stacked as proof ("Anyone can pick this up now.") + lesson ("Do the expensive thinking once, so the rest stays cheap.").

## Content & legibility

- Surfaced the real fluent API on the card (replacing generic filler), and corrected the imprecise "JUnit regression test" → "nested k8s tests in `HelmKubernetesTest`". Every card claim was verified against the live issue `manusa/helm-java#351` (title, Open state, labels, the `./mvnw test -pl helm-java` module command, and the `StatusCommand` reference impl).
- Removed the redundant `// act 04 · leverage` eyebrow and reworked the subtitle to seed the once-vs-N asymmetry.
- All must-read content now clears the 28px projection floor; remaining sub-floor runs are decorative chrome only. `audit:fit` reports 0 overflow on all three steps, and the `@media print` fallback flattens to the final step-2 state for the PDF handout.

## Scope

Only two files changed: `static/presentations/2026-devtalks-romania/index.html` and `styles/s-leverage.css`. CSS is scoped to `.s-leverage`; `snapshot:diff` confirms the change is isolated to slide 17.