### PR TITLE
feat(tooling): assert PDF export preserves clickable links

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -47,7 +47,7 @@ This is part of the deck-kit contract (`static/deck-kit/README.md` § URL hash).
 
 Four Playwright-backed scripts produce visual artifacts. All output goes under `./screenshots/` (gitignored). All capture at 1920×1080.
 
-**Batch-safe one-liners.** The capture/audit scripts are deliberately batch-safe: `screenshot`/`screenshot:deck`/`export:pdf`/`snapshot:baseline` exit 0 on success, `snapshot:diff` exits 1 only on a real pixel regression, and `audit:fit` exits 0 in report mode (non-zero only behind `--ci`). Point them straight at `serve:static` — the `networkidle` hang is gone (`scripts/lib/deck.js` → `gotoDeck`), so no throwaway `python3 -m http.server` host is needed. The remaining footgun is **raw `grep`/`curl` interposed in a chain**: `grep` exits **1** when it matches nothing and `curl` exits non-zero on any transport/non-2xx error, so under `&&`, a pipeline, or `set -euo pipefail` a harmless no-match aborts the rest of the batch. Guard any `grep`/`curl` whose empty result is acceptable with `|| true` (or `|| :`):
+**Batch-safe one-liners.** The capture/audit scripts are deliberately batch-safe: `screenshot`/`screenshot:deck`/`snapshot:baseline` exit 0 on success, `export:pdf` exits 0 on success but **1 if the exported PDF dropped a clickable link** (its built-in link-survival check), `snapshot:diff` exits 1 only on a real pixel regression, and `audit:fit` exits 0 in report mode (non-zero only behind `--ci`). Point them straight at `serve:static` — the `networkidle` hang is gone (`scripts/lib/deck.js` → `gotoDeck`), so no throwaway `python3 -m http.server` host is needed. The remaining footgun is **raw `grep`/`curl` interposed in a chain**: `grep` exits **1** when it matches nothing and `curl` exits non-zero on any transport/non-2xx error, so under `&&`, a pipeline, or `set -euo pipefail` a harmless no-match aborts the rest of the batch. Guard any `grep`/`curl` whose empty result is acceptable with `|| true` (or `|| :`):
 
 ```bash
 PORT=$(cat .live-server.port)                              # sidecar, written by serve:static
@@ -77,10 +77,24 @@ npm run screenshot:deck -- http://localhost:$(cat .live-server.port)/presentatio
 npm run screenshot -- http://localhost:$(cat .live-server.port)/presentations/2026-devtalks-romania/ s19-step1 --slide 19 --step 1
 ```
 
-**Whole deck → multi-page PDF** — `export:pdf`. Renders straight to a 1920×1080 vector PDF via Chromium's `page.pdf()` against the deck's `@media print` rule — text remains selectable, file size stays small (no rasterised slides). Photographic WebP `<image-slot>` sources are transcoded to JPEG just-in-time before render, because PDF doesn't support WebP and would otherwise embed each one as a multi-megabyte FlateDecode bitmap. Hand the output to conference organizers who require PDF.
+**Whole deck → multi-page PDF** — `export:pdf`. Renders straight to a 1920×1080 vector PDF via Chromium's `page.pdf()` against the deck's `@media print` rule — text remains selectable, file size stays small (no rasterised slides). Photographic WebP `<image-slot>` sources are transcoded to JPEG just-in-time before render, because PDF doesn't support WebP and would otherwise embed each one as a multi-megabyte FlateDecode bitmap. Hand the output to conference organizers who require PDF. As its **last step it runs the PDF link-survival check** (below) against the deck's own anchors and **exits non-zero if any clickable reference was dropped** — a broken PDF fails the export instead of shipping silently.
 ```bash
 npm run export:pdf -- http://localhost:$(cat .live-server.port)/presentations/2026-devtalks-romania/ /tmp/devtalks-2026.pdf
 ```
+
+**PDF link-survival check** — `test:pdf-links`. Asserts the deck's clickable references (`<a href>` anchors) survive into the exported PDF as link annotations. This guards against a future change to `export-pdf.js`, an `@media print` rule, or an `<a>` wrapper silently breaking link survival — which otherwise only surfaces when a viewer of the post-talk PDF reports a dead link. `export:pdf` invokes it automatically (reading the deck's anchors live from the DOM); run it standalone to inspect a PDF or re-check one:
+```bash
+# inspect: print every URL embedded in the PDF, exit 0
+npm run test:pdf-links -- /tmp/devtalks-2026.pdf
+
+# guard: derive the expected set live from the deck's index.html <a> anchors,
+# fail (exit 1, "missing: …") if any is absent from the PDF
+npm run test:pdf-links -- /tmp/devtalks-2026.pdf static/presentations/2026-devtalks-romania/
+
+# guard against an explicit JSON list of URLs instead of the deck markup
+npm run test:pdf-links -- /tmp/devtalks-2026.pdf path/to/expected-pdf-links.json
+```
+Only `<a href>` anchors count — stylesheet/font/preconnect `<link>`s and `og:`/`<meta>` URLs are not anchors and never become PDF link annotations, so they are excluded from the expected set. URLs are normalized for comparison, so a bare origin and its trailing-slash form (`https://blog.marcnuri.com` vs `…/`, as Chromium stores it) match. Backed by `pdf-lib` (pure JS, no native deps); the shared extraction/diff logic lives in `scripts/lib/pdf-links.js`, unit-tested under `tests/pdf-links/` (`node --test tests/pdf-links/*.spec.js`). This is a repo-level PDF-output concern, **not** a deck-kit one.
 
 **Step-aware capture**: a `<section>` that publishes `data-step-max="N"` becomes N+1 PDF pages (in `export:pdf`) and N+1 PNGs (in `screenshot:deck` / snapshot scripts), rendered at `data-step="0..N"`. This is the contract `.s-amplifier` uses (3 states per slide); any future stepping slide should follow it and all four scripts will pick it up with no code changes.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -34,7 +34,8 @@
         "pngjs": "7.0.0",
         "prop-types": "15.8.1",
         "qrcode": "1.5.4",
-        "sharp": "0.34.5"
+        "sharp": "0.34.5",
+        "pdf-lib": "1.17.1"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {
@@ -25098,6 +25099,46 @@
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/pdf-lib": {
+      "version": "1.17.1",
+      "resolved": "https://registry.npmjs.org/pdf-lib/-/pdf-lib-1.17.1.tgz",
+      "integrity": "sha512-V/mpyJAoTsN4cnP31vc0wfNA1+p20evqqnap0KLoRUN0Yk/p3wN52DOEsL4oBFcLdb76hlpKPtzJIgo67j/XLw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@pdf-lib/standard-fonts": "^1.0.0",
+        "@pdf-lib/upng": "^1.0.1",
+        "pako": "^1.0.11",
+        "tslib": "^1.11.1"
+      }
+    },
+    "node_modules/@pdf-lib/standard-fonts": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@pdf-lib/standard-fonts/-/standard-fonts-1.0.0.tgz",
+      "integrity": "sha512-hU30BK9IUN/su0Mn9VdlVKsWBS6GyhVfqjwl1FjZN4TxP6cCw0jP2w7V3Hf5uX7M0AZJ16vey9yE0ny7Sa59ZA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "pako": "^1.0.6"
+      }
+    },
+    "node_modules/@pdf-lib/upng": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@pdf-lib/upng/-/upng-1.0.1.tgz",
+      "integrity": "sha512-dQK2FUMQtowVP00mtIksrlZhdFXQZPC+taih1q4CvPZ5vqdxR/LKBaFg0oAfzd1GlHZXXSPdQfzQnt+ViGvEIQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "pako": "^1.0.10"
+      }
+    },
+    "node_modules/pako": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz",
+      "integrity": "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==",
+      "dev": true,
+      "license": "(MIT AND Zlib)"
     }
   },
   "dependencies": {
@@ -42305,6 +42346,42 @@
           }
         }
       }
+    },
+    "pdf-lib": {
+      "version": "1.17.1",
+      "resolved": "https://registry.npmjs.org/pdf-lib/-/pdf-lib-1.17.1.tgz",
+      "integrity": "sha512-V/mpyJAoTsN4cnP31vc0wfNA1+p20evqqnap0KLoRUN0Yk/p3wN52DOEsL4oBFcLdb76hlpKPtzJIgo67j/XLw==",
+      "dev": true,
+      "requires": {
+        "@pdf-lib/standard-fonts": "^1.0.0",
+        "@pdf-lib/upng": "^1.0.1",
+        "pako": "^1.0.11",
+        "tslib": "^1.11.1"
+      }
+    },
+    "@pdf-lib/standard-fonts": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@pdf-lib/standard-fonts/-/standard-fonts-1.0.0.tgz",
+      "integrity": "sha512-hU30BK9IUN/su0Mn9VdlVKsWBS6GyhVfqjwl1FjZN4TxP6cCw0jP2w7V3Hf5uX7M0AZJ16vey9yE0ny7Sa59ZA==",
+      "dev": true,
+      "requires": {
+        "pako": "^1.0.6"
+      }
+    },
+    "@pdf-lib/upng": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@pdf-lib/upng/-/upng-1.0.1.tgz",
+      "integrity": "sha512-dQK2FUMQtowVP00mtIksrlZhdFXQZPC+taih1q4CvPZ5vqdxR/LKBaFg0oAfzd1GlHZXXSPdQfzQnt+ViGvEIQ==",
+      "dev": true,
+      "requires": {
+        "pako": "^1.0.10"
+      }
+    },
+    "pako": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz",
+      "integrity": "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==",
+      "dev": true
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -24,7 +24,8 @@
     "snapshot:baseline": "node scripts/snapshot-baseline.js",
     "snapshot:diff": "node scripts/snapshot-diff.js",
     "audit:fit": "node scripts/audit-fit.js",
-    "test:deck-kit": "node --test tests/deck-kit/*.spec.js"
+    "test:deck-kit": "node --test tests/deck-kit/*.spec.js",
+    "test:pdf-links": "node scripts/test-pdf-links.js"
   },
   "publishConfig": {
     "access": "public"
@@ -67,7 +68,8 @@
   "jest": {
     "testPathIgnorePatterns": [
       "/node_modules/",
-      "/tests/deck-kit/"
+      "/tests/deck-kit/",
+      "/tests/pdf-links/"
     ]
   },
   "devDependencies": {
@@ -76,6 +78,7 @@
     "eslint-plugin-react": "7.37.5",
     "jest": "30.0.2",
     "live-server": "1.2.2",
+    "pdf-lib": "1.17.1",
     "pixelmatch": "7.2.0",
     "playwright": "1.60.0",
     "pngjs": "7.0.0",

--- a/scripts/export-pdf.js
+++ b/scripts/export-pdf.js
@@ -3,6 +3,7 @@
 const path = require('path');
 const fs = require('fs');
 const {gotoDeck, settleAnimations, applyExportHidden, expandStepClones} = require('./lib/deck');
+const {extractPdfUris, diffLinks} = require('./lib/pdf-links');
 
 const USAGE = `Usage: npm run export:pdf -- <deck-url> <output.pdf>
 
@@ -196,6 +197,45 @@ async function transcodePhotosToJpeg(page, {quality = 85} = {}) {
 
     const stat = fs.statSync(absOut);
     console.log(`✓ ${absOut} — ${totalAfterExpand} pages, ${(stat.size / 1024).toFixed(1)}KB`);
+
+    // Last step: assert every clickable reference in the deck survived into the
+    // PDF as a link annotation. The expected set is the deck's own <a href>
+    // anchors (read live from the DOM, excluding hidden export chrome), so this
+    // self-validates without a separate source of truth. A regression in the
+    // export pipeline, an @media print rule, or an <a> wrapper that drops links
+    // fails the export loudly instead of shipping a silently-broken PDF.
+    const expectedLinks = await page.evaluate(() => {
+      const urls = new Set();
+      document.querySelectorAll('a[href]').forEach((a) => {
+        const href = a.getAttribute('href');
+        if (href && /^https?:/i.test(href) && !a.closest('.export-hidden')) {
+          urls.add(href);
+        }
+      });
+      return [...urls];
+    });
+    if (expectedLinks.length > 0) {
+      const foundLinks = await extractPdfUris(fs.readFileSync(absOut));
+      const {missing, extra} = diffLinks(foundLinks, expectedLinks);
+      if (extra.length) {
+        console.warn(
+          `⚠ Link check: ${extra.length} URL${extra.length === 1 ? '' : 's'} in the PDF not present as a deck anchor:`
+        );
+        extra.forEach((u) => console.warn(`    extra: ${u}`));
+      }
+      if (missing.length) {
+        console.error(
+          `✗ Link check: ${missing.length}/${expectedLinks.length} anchor link${
+            missing.length === 1 ? '' : 's'
+          } missing from the PDF:`
+        );
+        missing.forEach((u) => console.error(`    missing: ${u}`));
+        console.error('The PDF was written but does not preserve every clickable reference.');
+        process.exitCode = 1;
+      } else {
+        console.log(`✓ Link check: all ${expectedLinks.length} anchor links preserved in the PDF.`);
+      }
+    }
   } finally {
     await browser.close();
   }

--- a/scripts/lib/pdf-links.js
+++ b/scripts/lib/pdf-links.js
@@ -1,0 +1,121 @@
+'use strict';
+
+/*
+ * pdf-links.js — shared helpers for asserting that the PDF export preserves the
+ * deck's clickable references.
+ *
+ * Used by two consumers:
+ *   - scripts/test-pdf-links.js  (standalone `npm run test:pdf-links`)
+ *   - scripts/export-pdf.js      (runs the check as the last step of an export)
+ *
+ * The three functions are pure (no I/O), so the work lives here and the callers
+ * only handle argv / page / file plumbing.
+ */
+
+const {PDFDocument, PDFName} = require('pdf-lib');
+
+/**
+ * Extract every external URI embedded as a Link annotation in a PDF.
+ *
+ * Chromium emits one `/Subtype /Link` annotation per `<a href>` anchor, with a
+ * URI action: `… /Annots [ << /A << /S /URI /URI (https://…) >> >> … ] …`. We
+ * walk each page's /Annots array, resolve indirect refs, and pull /A → /URI.
+ * Internal links (named destinations / GoTo actions) carry no /URI and are
+ * skipped — this only reports external anchor targets.
+ *
+ * @param {Uint8Array|Buffer} bytes raw PDF bytes
+ * @returns {Promise<string[]>} sorted, de-duplicated URI strings
+ */
+async function extractPdfUris(bytes) {
+  const doc = await PDFDocument.load(bytes, {updateMetadata: false});
+  const found = new Set();
+  for (const page of doc.getPages()) {
+    const annots = page.node.Annots();
+    if (!annots) continue;
+    for (let i = 0; i < annots.size(); i += 1) {
+      const annot = annots.lookup(i);
+      if (!annot || typeof annot.lookup !== 'function') continue;
+      const action = annot.lookup(PDFName.of('A'));
+      if (!action || typeof action.lookup !== 'function') continue;
+      const uri = action.lookup(PDFName.of('URI'));
+      if (uri && typeof uri.decodeText === 'function') {
+        found.add(uri.decodeText());
+      }
+    }
+  }
+  return [...found].sort();
+}
+
+/**
+ * Extract the external URLs of `<a href>` anchors from an HTML string.
+ *
+ * Deliberately matches `<a …>` only — `<link rel=stylesheet>`, font preconnect
+ * hints and `<meta>`/og URLs are not clickable anchors and never become PDF
+ * Link annotations, so they must not enter the expected set. Only http(s)
+ * targets are returned (mailto:, #hash and relative hrefs are ignored).
+ *
+ * The `href` token is required to be preceded by whitespace so it is matched as
+ * a standalone attribute, never as the tail of `data-href`. Double-, single- and
+ * unquoted attribute values are all accepted, so it stays aligned with the DOM
+ * collection in `export-pdf.js` (`getAttribute('href')`) regardless of quoting.
+ *
+ * Known limitation: as a regex over raw markup it cannot model rendered state —
+ * a literal `>` inside an attribute value before `href`, anchors hidden via
+ * `.export-hidden`, or anchors injected at runtime are out of its reach. For the
+ * authoritative, render-accurate check, `export-pdf.js` reads the live DOM; this
+ * function is the lightweight source-of-truth for static deck markup.
+ *
+ * @param {string} html
+ * @returns {string[]} sorted, de-duplicated anchor URLs
+ */
+function extractAnchorUrls(html) {
+  const urls = new Set();
+  const re = /<a\b[^>]*?\shref\s*=\s*(?:"(https?:\/\/[^"]+)"|'(https?:\/\/[^']+)'|(https?:\/\/[^\s"'>]+))/gi;
+  let m;
+  while ((m = re.exec(html)) !== null) {
+    urls.add(m[1] || m[2] || m[3]);
+  }
+  return [...urls].sort();
+}
+
+/**
+ * Normalize a URL for comparison so trivially-equivalent forms match — most
+ * importantly a bare origin (`https://blog.marcnuri.com`) and the trailing-slash
+ * form Chromium stores in the PDF (`https://blog.marcnuri.com/`). Paths, query
+ * strings and fragments are preserved. Unparseable strings compare verbatim.
+ *
+ * @param {string} u
+ * @returns {string}
+ */
+function normalizeUrl(u) {
+  try {
+    return new URL(u).href;
+  } catch {
+    return u;
+  }
+}
+
+/**
+ * Diff the URIs found in a PDF against the expected anchor set.
+ *
+ * @param {string[]} found    URIs extracted from the PDF
+ * @param {string[]} expected anchor URLs that should be present
+ * @returns {{missing: string[], extra: string[]}} `missing` = expected but not
+ *   in the PDF (the regression we guard against); `extra` = in the PDF but not
+ *   expected. Both list the original (un-normalized) strings, sorted.
+ */
+function diffLinks(found, expected) {
+  const foundNorm = new Map(found.map((u) => [normalizeUrl(u), u]));
+  const expectedNorm = new Map(expected.map((u) => [normalizeUrl(u), u]));
+  const missing = [...expectedNorm]
+    .filter(([key]) => !foundNorm.has(key))
+    .map(([, original]) => original)
+    .sort();
+  const extra = [...foundNorm]
+    .filter(([key]) => !expectedNorm.has(key))
+    .map(([, original]) => original)
+    .sort();
+  return {missing, extra};
+}
+
+module.exports = {extractPdfUris, extractAnchorUrls, normalizeUrl, diffLinks};

--- a/scripts/test-pdf-links.js
+++ b/scripts/test-pdf-links.js
@@ -1,0 +1,108 @@
+#!/usr/bin/env node
+/* eslint-disable no-console */
+const fs = require('fs');
+const path = require('path');
+const {extractPdfUris, extractAnchorUrls, diffLinks} = require('./lib/pdf-links');
+
+const USAGE = `Usage: npm run test:pdf-links -- <pdf> [<expected>]
+
+  <pdf>        Path to an exported PDF (produced by \`npm run export:pdf\`).
+  <expected>   Optional source of truth for the anchor URLs that must survive:
+                 • a deck directory or index.html  → expected = its <a href> anchors
+                 • a .json file (array of URL strings) → expected = that list
+
+Modes:
+  test:pdf-links -- <pdf>
+      Print every URL found in the PDF, sorted. Exit 0. (inspection)
+
+  test:pdf-links -- <pdf> static/presentations/2026-devtalks-romania/
+      Derive the expected URLs live from the deck's index.html <a> anchors and
+      assert every one survived into the PDF. Exit 1 on any "missing:".
+
+  test:pdf-links -- <pdf> expected-pdf-links.json
+      Compare against an explicit JSON array of URLs. Exit 1 on any "missing:".
+
+Extra URLs found in the PDF beyond the expected set are reported as a warning
+but do not fail the check (matches the export pipeline's own guard).
+
+Examples:
+  npm run export:pdf -- http://localhost:$(cat .live-server.port)/presentations/2026-devtalks-romania/ /tmp/devtalks-2026.pdf
+  npm run test:pdf-links -- /tmp/devtalks-2026.pdf static/presentations/2026-devtalks-romania/
+`;
+
+const args = process.argv.slice(2);
+if (args.length === 0 || args[0] === '-h' || args[0] === '--help') {
+  console.log(USAGE);
+  process.exit(args.length === 0 ? 1 : 0);
+}
+if (args.length > 2) {
+  console.error('Expected at most two arguments: <pdf> [<expected>]');
+  process.exit(1);
+}
+
+const [pdfPath, expectedPath] = args;
+
+if (!fs.existsSync(pdfPath)) {
+  console.error(`PDF not found: ${pdfPath}`);
+  process.exit(1);
+}
+
+/**
+ * Resolve the expected anchor URLs from the second argument:
+ *   - a .json file → parse the array verbatim
+ *   - a directory  → read <dir>/index.html and extract its <a> anchors
+ *   - an .html file → extract its <a> anchors
+ */
+function loadExpected(p) {
+  if (p.toLowerCase().endsWith('.json')) {
+    const parsed = JSON.parse(fs.readFileSync(p, 'utf8'));
+    if (!Array.isArray(parsed)) {
+      throw new Error(`Expected-list JSON must be an array of URL strings: ${p}`);
+    }
+    return [...new Set(parsed)].sort();
+  }
+  let htmlPath = p;
+  if (fs.statSync(p).isDirectory()) {
+    htmlPath = path.join(p, 'index.html');
+  }
+  if (!fs.existsSync(htmlPath)) {
+    throw new Error(`No index.html to derive expected anchors from: ${htmlPath}`);
+  }
+  return extractAnchorUrls(fs.readFileSync(htmlPath, 'utf8'));
+}
+
+(async () => {
+  const found = await extractPdfUris(fs.readFileSync(pdfPath));
+
+  if (!expectedPath) {
+    if (found.length === 0) {
+      console.log('No URLs found in the PDF.');
+    } else {
+      found.forEach((u) => console.log(u));
+    }
+    process.exit(0);
+  }
+
+  const expected = loadExpected(expectedPath);
+  const {missing, extra} = diffLinks(found, expected);
+
+  console.log(`Found ${found.length} URL${found.length === 1 ? '' : 's'} in ${pdfPath}`);
+  console.log(`Expected ${expected.length} anchor URL${expected.length === 1 ? '' : 's'} from ${expectedPath}`);
+
+  if (extra.length) {
+    console.warn(`\n⚠ ${extra.length} extra URL${extra.length === 1 ? '' : 's'} in the PDF (not in expected set):`);
+    extra.forEach((u) => console.warn(`  extra: ${u}`));
+  }
+
+  if (missing.length) {
+    console.error(`\n✗ ${missing.length} expected URL${missing.length === 1 ? '' : 's'} missing from the PDF:`);
+    missing.forEach((u) => console.error(`  missing: ${u}`));
+    process.exit(1);
+  }
+
+  console.log(`\n✓ All ${expected.length} expected anchor URLs are present in the PDF.`);
+  process.exit(0);
+})().catch((err) => {
+  console.error(err.message || err);
+  process.exit(1);
+});

--- a/tests/pdf-links/pdf-links.spec.js
+++ b/tests/pdf-links/pdf-links.spec.js
@@ -1,0 +1,145 @@
+'use strict';
+
+const {test} = require('node:test');
+const assert = require('node:assert/strict');
+const {PDFDocument, PDFName, PDFString} = require('pdf-lib');
+
+const {extractPdfUris, extractAnchorUrls, normalizeUrl, diffLinks} = require('../../scripts/lib/pdf-links');
+
+/**
+ * Build an in-memory PDF whose pages carry URI Link annotations, mirroring the
+ * structure Chromium emits for `<a href>` anchors (Annots → /A → /URI). Each
+ * entry in `pagesUris` is one page; its array lists the URIs to attach.
+ */
+async function buildPdf(pagesUris) {
+  const doc = await PDFDocument.create();
+  const ctx = doc.context;
+  for (const uris of pagesUris) {
+    const page = doc.addPage([600, 400]);
+    const refs = uris.map((uri) =>
+      ctx.register(
+        ctx.obj({
+          Type: PDFName.of('Annot'),
+          Subtype: PDFName.of('Link'),
+          Rect: [0, 0, 100, 20],
+          A: ctx.obj({Type: PDFName.of('Action'), S: PDFName.of('URI'), URI: PDFString.of(uri)}),
+        })
+      )
+    );
+    if (refs.length) page.node.set(PDFName.of('Annots'), ctx.obj(refs));
+  }
+  return doc.save();
+}
+
+test('extractPdfUris returns sorted, de-duplicated URIs across all pages', async () => {
+  const bytes = await buildPdf([
+    ['https://example.com/b', 'https://example.com/a'],
+    ['https://example.com/a', 'https://github.com/manusa/yakd/pull/172'],
+  ]);
+  const uris = await extractPdfUris(bytes);
+  assert.deepEqual(uris, [
+    'https://example.com/a',
+    'https://example.com/b',
+    'https://github.com/manusa/yakd/pull/172',
+  ]);
+});
+
+test('extractPdfUris returns [] for a PDF with no link annotations', async () => {
+  const bytes = await buildPdf([[], []]);
+  assert.deepEqual(await extractPdfUris(bytes), []);
+});
+
+test('extractPdfUris preserves query strings with percent-encoding', async () => {
+  const url = 'https://github.com/fabric8io/kubernetes-client/issues?q=is%3Aclosed+label%3Aflaky';
+  const bytes = await buildPdf([[url]]);
+  assert.deepEqual(await extractPdfUris(bytes), [url]);
+});
+
+test('extractAnchorUrls picks only <a> http(s) hrefs, de-duplicated and sorted', () => {
+  const html = `
+    <link rel="stylesheet" href="https://cdn.example.com/all.css">
+    <link rel="preconnect" href="https://fonts.gstatic.com">
+    <a href="https://github.com/manusa/yakd">yakd</a>
+    <a class="ref-link overlay" href="https://github.com/manusa" aria-label="x"></a>
+    <a href="https://github.com/manusa/yakd">yakd again (dupe)</a>
+    <a href="mailto:marc@marcnuri.com">mail</a>
+    <a href="#5">internal hash</a>
+    <a href="/relative/path">relative</a>
+  `;
+  assert.deepEqual(extractAnchorUrls(html), [
+    'https://github.com/manusa',
+    'https://github.com/manusa/yakd',
+  ]);
+});
+
+test('extractAnchorUrls accepts double-, single- and unquoted href values', () => {
+  const html = `
+    <a href="https://example.com/double">double</a>
+    <a href='https://example.com/single'>single</a>
+    <a href=https://example.com/unquoted>unquoted</a>
+  `;
+  assert.deepEqual(extractAnchorUrls(html), [
+    'https://example.com/double',
+    'https://example.com/single',
+    'https://example.com/unquoted',
+  ]);
+});
+
+test('extractAnchorUrls does not mistake data-href for href', () => {
+  // \shref guard: the href token must be a standalone attribute, never the tail
+  // of data-href. The real href on the second anchor must still be picked up.
+  const html = `
+    <a data-href="https://example.com/not-a-real-href">decoy</a>
+    <a data-href="https://example.com/decoy" href="https://example.com/real">both</a>
+  `;
+  assert.deepEqual(extractAnchorUrls(html), ['https://example.com/real']);
+});
+
+test('extractAnchorUrls handles href after other attributes and across lines', () => {
+  const html = `<a
+      class="ref-link overlay"
+      target="_blank"
+      href="https://example.com/multiline"
+      rel="noopener">x</a>`;
+  assert.deepEqual(extractAnchorUrls(html), ['https://example.com/multiline']);
+});
+
+test('normalizeUrl lowercases scheme/host and equates bare origin with trailing slash', () => {
+  assert.equal(normalizeUrl('HTTPS://Example.com'), normalizeUrl('https://example.com/'));
+});
+
+test('normalizeUrl leaves an unparseable string verbatim', () => {
+  assert.equal(normalizeUrl('not a url'), 'not a url');
+});
+
+test('diffLinks reports missing expected URLs', () => {
+  const found = ['https://github.com/manusa/yakd'];
+  const expected = ['https://github.com/manusa/yakd', 'https://example.com/does-not-exist'];
+  const {missing, extra} = diffLinks(found, expected);
+  assert.deepEqual(missing, ['https://example.com/does-not-exist']);
+  assert.deepEqual(extra, []);
+});
+
+test('diffLinks reports extra URLs found beyond the expected set', () => {
+  const found = ['https://github.com/manusa/yakd', 'https://github.com/manusa/extra'];
+  const expected = ['https://github.com/manusa/yakd'];
+  const {missing, extra} = diffLinks(found, expected);
+  assert.deepEqual(missing, []);
+  assert.deepEqual(extra, ['https://github.com/manusa/extra']);
+});
+
+test('diffLinks treats a bare origin and its trailing-slash form as equal', () => {
+  // Chromium may store https://blog.marcnuri.com as https://blog.marcnuri.com/
+  const found = ['https://blog.marcnuri.com/'];
+  const expected = ['https://blog.marcnuri.com'];
+  const {missing, extra} = diffLinks(found, expected);
+  assert.deepEqual(missing, []);
+  assert.deepEqual(extra, []);
+});
+
+test('diffLinks returns empty missing/extra when sets match', () => {
+  const urls = ['https://a.test', 'https://b.test'];
+  const {missing, extra} = diffLinks(urls, urls);
+  assert.deepEqual(missing, []);
+  assert.deepEqual(extra, []);
+});


### PR DESCRIPTION
## Summary

Adds an automated check that the PDF export preserves the deck's clickable
references, replacing the manual "open the PDF and click a few links"
verification that was fragile against changes to `export-pdf.js`, `@media print`
rules, or `<a>` wrappers.

- **New `npm run test:pdf-links`:**
  - *print mode* — `test:pdf-links -- <pdf>` lists every URL embedded in the PDF (exit 0).
  - *guard mode* — `test:pdf-links -- <pdf> <deck-dir|index.html>` derives the expected set live from the deck's `<a href>` anchors and exits 1 with `missing: …` if any is absent. Also accepts an explicit JSON list of URLs.
- **`export:pdf` runs the check as its last step** (reading the deck's anchors live from the DOM) and exits non-zero if any clickable reference was dropped, so a silently-broken PDF fails the export.
- Shared extraction/diff logic in `scripts/lib/pdf-links.js`, backed by `pdf-lib` (pure JS, no native deps), unit-tested under `tests/pdf-links/` (`node --test`).
- Documented in `AGENTS.md` / `CLAUDE.md` next to `export:pdf`.

Only `<a href>` anchors count — stylesheet/font/preconnect `<link>`s and `og:`/`<meta>` URLs are excluded. URLs are normalized so a bare origin and its trailing-slash form match.

## Verification

- Unit tests: **13/13 pass** (`node --test tests/pdf-links/*.spec.js`).
- `export:pdf` against the devtalks-2026 deck: **all 33 anchor links preserved, exit 0**.
- Failure path (disposable fixture with a dropped link): reports `missing: …`, **exit 1**.
- `test:pdf-links` print mode: 33 URLs, exit 0; negative test with a fake URL: **exit 1**.

No deck-kit changes. No CI wiring (can be a follow-up).

Closes manusa/com.marcnuri.automated-tasks#1825