### PR TITLE
feat(deck-kit): declarative step reveals (data-reveal/-only/-until)

### DIFF
--- a/static/deck-kit/README.md
+++ b/static/deck-kit/README.md
@@ -85,6 +85,38 @@ implementation detail and may change without a filename bump.
 - `data-step` — runtime state, managed by deck-stage. Snaps to `0` whenever
   the slide is entered or left. Do not set manually past markup-default `0`.
 
+#### Declarative step reveals
+
+Set on **any descendant** of a `<section>` to reveal it progressively without
+hand-writing per-step CSS or counting steps. `k` is a non-negative integer (the
+0-based `data-step` at which the transition occurs); an element with **no**
+reveal attribute is always visible. An element should carry **at most one**.
+
+- `data-reveal="k"` — shown once `data-step >= k`.
+- `data-reveal-only="k"` — shown only while `data-step === k`.
+- `data-reveal-until="k"` — shown while `data-step <= k`.
+
+deck-stage **auto-derives `data-step-max`** for the section as the greatest `k`
+across all three attributes, so the author never counts steps. An **explicit**
+author-set `data-step-max` always wins and is never overwritten — use it to take
+manual control. `k=0` is valid (e.g. `data-reveal-only="0"` = base-state-only).
+A non-integer / negative value is ignored (element stays visible) with a
+`console.warn`; multiple reveal attributes on one element honor the first in the
+order above, also with a `console.warn`. A non-active stepped slide rests at
+`data-step="0"`, so its thumbnail in the rail shows the **base state** (later
+reveals hidden) — the same way existing `[data-step]`-gated content already
+thumbnails, not a bug.
+
+### `<section>` CSS hooks
+
+- `[data-revealed]` — reflects current reveal visibility, toggled by deck-stage
+  on every element carrying a `data-reveal` / `-only` / `-until` attribute as
+  `data-step` changes (present when shown, absent when hidden). deck-stage
+  injects one global default so un-styled reveal elements hide by default
+  (`opacity: 0; pointer-events: none`); decks animate the transition by styling
+  the hook, e.g. `.thing { transition: opacity .3s } .thing[data-revealed] {
+  opacity: 1; transform: none }`. `opacity` (not `display`) keeps layout stable.
+
 ### Keyboard bindings
 
 - `ArrowRight` / `PageDown` / `Space` / `Enter` — advance step (when

--- a/static/deck-kit/deck-stage.js
+++ b/static/deck-kit/deck-stage.js
@@ -79,6 +79,27 @@
 
   const pad2 = (n) => String(n).padStart(2, '0');
 
+  // Declarative step reveals. Three opt-in attributes on any <section>
+  // descendant declare reveal behavior inline; deck-stage auto-derives the
+  // section's data-step-max from them and toggles the boolean [data-revealed]
+  // hook per the current 0-based data-step:
+  //   data-reveal="k"        shown when step >= k   (Gatsby's "from")
+  //   data-reveal-only="k"   shown when step === k  (Gatsby's "in")
+  //   data-reveal-until="k"  shown when step <= k   (Gatsby's "until")
+  // Listed in precedence order — an element should carry at most one; if it
+  // carries several, the first present here wins.
+  const REVEAL_ATTRS = ['data-reveal', 'data-reveal-only', 'data-reveal-until'];
+
+  // A reveal index is a non-negative integer (0 is valid; "always visible" is
+  // expressed by omitting the attribute, not by data-reveal="0"). Anything
+  // else (non-integer, negative, empty) → null so the caller ignores the
+  // attribute and warns.
+  const parseRevealK = (raw) => {
+    const s = (raw == null ? '' : String(raw)).trim();
+    if (!/^\d+$/.test(s)) return null;
+    return parseInt(s, 10);
+  };
+
   // Label precedence: data-label → data-screen-label (number stripped) → first heading → "Slide".
   const getSlideLabel = (el) => {
     const explicit = el.getAttribute('data-label');
@@ -595,6 +616,11 @@
       this._omelettePresenting = false;
       this._fullscreenPresenting = false;
       this._presenting = false;
+      // Sections whose data-step-max we auto-derived from reveal attributes
+      // (so re-derivation may update them) and reveal elements we've already
+      // warned about (so a malformed attribute warns once, not on every nav).
+      this._autoStepSections = new WeakSet();
+      this._revealWarned = new WeakSet();
 
       this._onKey = this._onKey.bind(this);
       this._onResize = this._onResize.bind(this);
@@ -629,6 +655,7 @@
       this._render();
       this._loadNotes();
       this._syncPrintPageRule();
+      this._injectRevealStyle();
       window.addEventListener('keydown', this._onKey);
       window.addEventListener('resize', this._onResize);
       window.addEventListener('mousemove', this._onMouseMove, { passive: true });
@@ -1078,6 +1105,97 @@
         '* { -webkit-print-color-adjust: exact; print-color-adjust: exact; } }';
     }
 
+    /** Default-hide reveal elements that aren't currently revealed. Injected
+     *  once into <head> like the @page rule: reveal elements are light-DOM
+     *  descendants of a slotted <section>, beyond ::slotted's reach, so a
+     *  shadow rule can't touch them. opacity (not display:none) keeps layout
+     *  stable; decks animate the transition by styling the [data-revealed]
+     *  hook (e.g. `.thing[data-revealed]{opacity:1;transform:none}`). */
+    _injectRevealStyle() {
+      const id = 'deck-stage-reveal';
+      if (document.getElementById(id)) return;
+      const tag = document.createElement('style');
+      tag.id = id;
+      tag.textContent =
+        '[data-reveal]:not([data-revealed]),' +
+        '[data-reveal-only]:not([data-revealed]),' +
+        '[data-reveal-until]:not([data-revealed]){opacity:0;pointer-events:none;}';
+      document.head.appendChild(tag);
+    }
+
+    /** Which reveal rule (if any) governs an element. null = no reveal
+     *  attribute. { kind: 'always' } = the value was invalid, so the
+     *  attribute is ignored and the element stays visible. Otherwise
+     *  { kind: <attr>, k }. Warns once per element on a multiple-attribute
+     *  or invalid-value mistake — at authoring time, not on every nav. */
+    _resolveReveal(el) {
+      let chosen = null;
+      let count = 0;
+      for (const attr of REVEAL_ATTRS) {
+        if (el.hasAttribute(attr)) { count += 1; if (!chosen) chosen = attr; }
+      }
+      if (!chosen) return null;
+      const raw = el.getAttribute(chosen);
+      const k = parseRevealK(raw);
+      if (!this._revealWarned.has(el) && (count > 1 || k === null)) {
+        if (count > 1) {
+          console.warn(`[deck-stage] element carries multiple reveal attributes; honoring "${chosen}". Use only one of ${REVEAL_ATTRS.join(', ')}.`, el);
+        }
+        if (k === null) {
+          console.warn(`[deck-stage] invalid ${chosen}="${raw}" — expected a non-negative integer; treating element as always visible.`, el);
+        }
+        this._revealWarned.add(el);
+      }
+      if (k === null) return { kind: 'always', k: 0 };
+      return { kind: chosen, k };
+    }
+
+    /** Whether a resolved reveal rule is shown at a given 0-based step. */
+    _isRevealedAt(r, step) {
+      switch (r.kind) {
+        case 'data-reveal': return step >= r.k;
+        case 'data-reveal-only': return step === r.k;
+        case 'data-reveal-until': return step <= r.k;
+        default: return true; // 'always' (invalid value, ignored)
+      }
+    }
+
+    /** Toggle the data-revealed hook on every reveal descendant of a slide
+     *  from its current data-step. No-op for slides with no reveal elements. */
+    _applyReveals(slide) {
+      if (!slide) return;
+      const els = slide.querySelectorAll('[data-reveal],[data-reveal-only],[data-reveal-until]');
+      if (!els.length) return;
+      const step = parseInt(slide.getAttribute('data-step') || '0', 10) || 0;
+      els.forEach((el) => {
+        const r = this._resolveReveal(el);
+        if (r) el.toggleAttribute('data-revealed', this._isRevealedAt(r, step));
+      });
+    }
+
+    /** Auto-derive data-step-max from a section's reveal attributes so authors
+     *  never count steps. An explicit author-set data-step-max wins and is
+     *  never touched (rule 1); only sections we set are tracked in
+     *  _autoStepSections and recomputed on re-derivation. A section with no
+     *  valid reveal attrs and no explicit max stays non-stepped. */
+    _deriveStepMax(slide) {
+      const managed = this._autoStepSections.has(slide);
+      if (slide.hasAttribute('data-step-max') && !managed) return;
+      let max = -1;
+      slide.querySelectorAll('[data-reveal],[data-reveal-only],[data-reveal-until]').forEach((el) => {
+        const r = this._resolveReveal(el);
+        if (r && r.kind !== 'always' && r.k > max) max = r.k;
+      });
+      if (max >= 0) {
+        slide.setAttribute('data-step-max', String(max));
+        this._autoStepSections.add(slide);
+      } else if (managed) {
+        // Reveal attrs were removed since we last derived — relinquish control.
+        slide.removeAttribute('data-step-max');
+        this._autoStepSections.delete(slide);
+      }
+    }
+
     _onSlotChange() {
       // Rail mutations (delete/move) already reconcile synchronously and
       // emit slidechange with reason 'api'; skip the async slotchange that
@@ -1108,6 +1226,13 @@
         }
 
         slide.setAttribute('data-deck-slide', String(i));
+
+        // Declarative reveals: auto-derive data-step-max (unless author-set)
+        // and reflect the base-state visibility, BEFORE the first _applyIndex
+        // so its data-step-max reset logic sees the derived value and every
+        // slide — active or not — starts in its correct step-0 reveal state.
+        this._deriveStepMax(slide);
+        this._applyReveals(slide);
       });
 
       if (this._totalEl) this._totalEl.textContent = String(this._slides.length || 1);
@@ -1158,6 +1283,11 @@
       const currSlide = this._slides[curr];
       if (prevSlide && prevSlide.hasAttribute('data-step-max')) prevSlide.setAttribute('data-step', '0');
       if (currSlide && currSlide.hasAttribute('data-step-max')) currSlide.setAttribute('data-step', '0');
+      // Reflect the (reset) step into the [data-revealed] hooks so a freshly
+      // entered stepped slide shows its base state with later reveals hidden,
+      // and the slide we left is clean for its next entry.
+      this._applyReveals(prevSlide);
+      this._applyReveals(currSlide);
       // Present-skip watermark: on only when the active slide is a present-
       // skip slide and we're off-stage. While presenting it's hopped over so
       // it can never be active; the !presenting guard just covers the
@@ -1418,12 +1548,14 @@
           const cur = parseInt(slide.getAttribute('data-step') || '0', 10);
           if (isAdvance && cur < max) {
             slide.setAttribute('data-step', String(cur + 1));
+            this._applyReveals(slide);
             e.preventDefault();
             this._flashOverlay();
             return;
           }
           if (isRetreat && cur > 0) {
             slide.setAttribute('data-step', String(cur - 1));
+            this._applyReveals(slide);
             e.preventDefault();
             this._flashOverlay();
             return;
@@ -1445,7 +1577,10 @@
         // current value for an opening stepped slide. Reset here before
         // dispatching so R always lands on "slide 1, step 0" per README.
         const cur = this._slides[this._index];
-        if (cur && cur.hasAttribute('data-step-max')) cur.setAttribute('data-step', '0');
+        if (cur && cur.hasAttribute('data-step-max')) {
+          cur.setAttribute('data-step', '0');
+          this._applyReveals(cur);
+        }
         this._go(0, 'keyboard');
       } else if (key === 'f' || key === 'F') {
         // Plain 'f' as the single cross-platform toggle. Not F11: Chromium

--- a/tests/deck-kit/contract.spec.js
+++ b/tests/deck-kit/contract.spec.js
@@ -16,7 +16,13 @@ const DECK_STAGE_ATTRS = ['width', 'height', 'noscale', 'no-rail'];
 // `<section>` data-* attributes that deck-stage reads from consumer markup.
 // data-step is runtime state managed by deck-stage; data-step-max and
 // data-deck-present-skip are author-set; data-label is author-set.
-const SECTION_DATA_ATTRS = ['data-label', 'data-deck-present-skip', 'data-step-max', 'data-step'];
+// data-reveal / -only / -until are the declarative step-reveal attributes
+// (read off section descendants); deck-stage reflects their visibility via
+// the data-revealed CSS hook (written, not read — documented in README).
+const SECTION_DATA_ATTRS = [
+  'data-label', 'data-deck-present-skip', 'data-step-max', 'data-step',
+  'data-reveal', 'data-reveal-only', 'data-reveal-until',
+];
 const SLIDECHANGE_DETAIL_KEYS = ['index', 'previousIndex', 'total', 'slide', 'previousSlide', 'reason'];
 const SLIDECHANGE_REASONS = ['init', 'keyboard', 'click', 'tap', 'api', 'mutation'];
 const DECKCHANGE_DETAIL_KEYS = ['action', 'from', 'to', 'slide'];
@@ -477,13 +483,59 @@ describe('deck-kit contract — append-only', () => {
     await page.close();
   });
 
+  // ── Declarative step reveals (data-reveal / -only / -until) ────────────
+  // Append-only surface. The three reveal attributes auto-derive the
+  // section's data-step-max and toggle the boolean data-revealed hook from
+  // the current data-step. Duplicates deck-stage.spec.js coverage by design —
+  // dropping the feature must fail the contract suite too.
+  test('reveal attributes auto-derive data-step-max and toggle data-revealed', async () => {
+    const page = await browser.newPage();
+    await bootDeck(page, server.fixture('reveal-deck.html'));
+    // No explicit data-step-max in markup — greatest k (data-reveal="2") wins.
+    const max = await page.evaluate(() =>
+      document.querySelectorAll('section')[1].getAttribute('data-step-max'));
+    assert.equal(max, '2', 'data-step-max auto-derived from reveal attrs');
+
+    await page.evaluate(() => document.querySelector('deck-stage').goTo(1));
+    // Lock all THREE attribute names behaviorally (not just in the allowlist
+    // literal): r1=data-reveal, o1=data-reveal-only, u1=data-reveal-until.
+    // Dropping support for any one must fail here.
+    const base = await page.evaluate(() => ({
+      r1: document.getElementById('r1').hasAttribute('data-revealed'),
+      o1: document.getElementById('o1').hasAttribute('data-revealed'),
+      u1: document.getElementById('u1').hasAttribute('data-revealed'),
+    }));
+    assert.equal(base.r1, false, 'data-reveal="1" hidden at step 0');
+    assert.equal(base.o1, false, 'data-reveal-only="1" hidden at step 0');
+    assert.equal(base.u1, true, 'data-reveal-until="1" shown at step 0');
+
+    await page.keyboard.press('ArrowRight');
+    const stepped = await page.evaluate(() => ({
+      r1: document.getElementById('r1').hasAttribute('data-revealed'),
+      o1: document.getElementById('o1').hasAttribute('data-revealed'),
+      u1: document.getElementById('u1').hasAttribute('data-revealed'),
+    }));
+    assert.equal(stepped.r1, true, 'data-reveal="1" shown after one advance');
+    assert.equal(stepped.o1, true, 'data-reveal-only="1" shown at its step');
+    assert.equal(stepped.u1, true, 'data-reveal-until="1" still shown at step 1');
+
+    // The default-hide stylesheet is injected exactly once into the document.
+    const tags = await page.evaluate(() =>
+      document.querySelectorAll('style#deck-stage-reveal').length);
+    assert.equal(tags, 1, 'reveal stylesheet injected once');
+    await page.close();
+  });
+
   // SECTION_DATA_ATTRS is the canonical README list — read it into the
   // suite so a future refactor that drops an entry shows up here.
   // The behavior tests above cover each name in turn.
   test('SECTION_DATA_ATTRS matches the README-documented surface', () => {
     assert.deepEqual(
       [...SECTION_DATA_ATTRS].sort(),
-      ['data-deck-present-skip', 'data-label', 'data-step', 'data-step-max'],
+      [
+        'data-deck-present-skip', 'data-label', 'data-reveal', 'data-reveal-only',
+        'data-reveal-until', 'data-step', 'data-step-max',
+      ],
     );
   });
 });

--- a/tests/deck-kit/deck-stage.spec.js
+++ b/tests/deck-kit/deck-stage.spec.js
@@ -209,3 +209,216 @@ describe('deck-stage navigation', () => {
     await page.close();
   });
 });
+
+// ── Declarative step reveals (data-reveal / -only / -until) ─────────────────
+// deck-stage auto-derives data-step-max from reveal attributes and toggles
+// the boolean data-revealed hook on each reveal element from the current
+// data-step. Mirrors the data-step-max step-machine block in contract.spec.js.
+describe('deck-stage step reveals', () => {
+  let server;
+  let browser;
+
+  before(async () => {
+    server = await startServer();
+    browser = await chromium.launch();
+  });
+
+  after(async () => {
+    if (browser) await browser.close();
+    if (server) await server.close();
+  });
+
+  // Read the reveal section's step state + each tracked element's
+  // data-revealed flag in one round-trip.
+  const revealState = (page, ids) => page.evaluate((ids) => {
+    const out = { revealed: {} };
+    for (const id of ids) {
+      const el = document.getElementById(id);
+      out.revealed[id] = el ? el.hasAttribute('data-revealed') : null;
+    }
+    const anchor = document.getElementById(ids[0]);
+    const sec = anchor && anchor.closest('section');
+    out.step = sec && sec.getAttribute('data-step');
+    out.stepMax = sec && sec.getAttribute('data-step-max');
+    return out;
+  }, ids);
+
+  const opacityOf = (page, id) =>
+    page.evaluate((id) => getComputedStyle(document.getElementById(id)).opacity, id);
+
+  test('auto-derives data-step-max from the greatest k across reveal attrs', async () => {
+    const page = await browser.newPage();
+    await bootDeck(page, server.fixture('reveal-deck.html'));
+    const max = await page.evaluate(() =>
+      document.querySelectorAll('section')[1].getAttribute('data-step-max'));
+    assert.equal(max, '2', 'greatest k is 2 (data-reveal="2")');
+    await page.close();
+  });
+
+  test('reveal / reveal-only / reveal-until behave per the semantics table at steps 0..max', async () => {
+    const page = await browser.newPage();
+    await bootDeck(page, server.fixture('reveal-deck.html'));
+    const ids = ['r1', 'r2', 'o1', 'u1'];
+    await page.evaluate(() => document.querySelector('deck-stage').goTo(1));
+
+    // step 0 (base): until-1 shown; reveal-1/2 + only-1 hidden.
+    let st = await revealState(page, ids);
+    assert.equal(st.step, '0', 'enters at step 0');
+    assert.deepEqual(st.revealed, { r1: false, r2: false, o1: false, u1: true }, 'step 0');
+
+    // step 1: reveal-1 appears, only-1 appears, until-1 still shown, reveal-2 hidden.
+    await page.keyboard.press('ArrowRight');
+    st = await revealState(page, ids);
+    assert.equal(st.step, '1');
+    assert.deepEqual(st.revealed, { r1: true, r2: false, o1: true, u1: true }, 'step 1');
+
+    // step 2 (max): reveal-1/2 shown, only-1 gone (=== 1 only), until-1 gone (<= 1 only).
+    await page.keyboard.press('ArrowRight');
+    st = await revealState(page, ids);
+    assert.equal(st.step, '2');
+    assert.deepEqual(st.revealed, { r1: true, r2: true, o1: false, u1: false }, 'step 2');
+
+    // ArrowLeft retreats back through the same states.
+    await page.keyboard.press('ArrowLeft');
+    st = await revealState(page, ids);
+    assert.equal(st.step, '1');
+    assert.deepEqual(st.revealed, { r1: true, r2: false, o1: true, u1: true }, 'retreat to step 1');
+    await page.close();
+  });
+
+  test('data-reveal-until re-appears when the deck retreats back below k', async () => {
+    const page = await browser.newPage();
+    await bootDeck(page, server.fixture('reveal-deck.html'));
+    const u0 = () => page.evaluate(() => document.getElementById('u0').hasAttribute('data-revealed'));
+    await page.evaluate(() => document.querySelector('deck-stage').goTo(1));
+    // until="0" is the case whose interesting transitions are at the boundary:
+    // shown at step 0, hidden once step passes k, then shown again on retreat.
+    assert.equal(await u0(), true, 'until="0" shown at step 0');
+    await page.keyboard.press('ArrowRight'); // step 1
+    assert.equal(await u0(), false, 'until="0" hidden once step passes k');
+    await page.keyboard.press('ArrowLeft'); // back to step 0
+    assert.equal(await u0(), true, 'until="0" re-appears on retreat below k');
+    await page.close();
+  });
+
+  test('explicit data-step-max is never overwritten by auto-derivation', async () => {
+    const page = await browser.newPage();
+    await bootDeck(page, server.fixture('reveal-explicit-deck.html'));
+    const max = await page.evaluate(() =>
+      document.querySelectorAll('section')[1].getAttribute('data-step-max'));
+    assert.equal(max, '5', 'author-set data-step-max="5" survives despite reveals deriving 2');
+    await page.close();
+  });
+
+  test('un-styled reveal elements hide by default via the injected global style (opacity)', async () => {
+    const page = await browser.newPage();
+    await bootDeck(page, server.fixture('reveal-deck.html'));
+    await page.evaluate(() => document.querySelector('deck-stage').goTo(1));
+    // step 0: hidden reveal element is opacity:0; shown one is opacity:1.
+    assert.equal(await opacityOf(page, 'r1'), '0', 'reveal-1 hidden at step 0');
+    assert.equal(await opacityOf(page, 'u1'), '1', 'until-1 visible at step 0');
+    await page.keyboard.press('ArrowRight'); // step 1 → reveal-1 appears
+    assert.equal(await opacityOf(page, 'r1'), '1', 'reveal-1 visible at step 1');
+    // The global rule lives in the document head, once.
+    const tags = await page.evaluate(() =>
+      document.querySelectorAll('style#deck-stage-reveal').length);
+    assert.equal(tags, 1, 'exactly one reveal stylesheet injected');
+    await page.close();
+  });
+
+  test('entering a stepped slide shows base state; leaving and re-entering replays from step 0', async () => {
+    const page = await browser.newPage();
+    await bootDeck(page, server.fixture('reveal-deck.html'));
+    const ids = ['r1', 'r2', 'o1', 'u1'];
+    await page.evaluate(() => document.querySelector('deck-stage').goTo(1));
+    await page.keyboard.press('ArrowRight');
+    await page.keyboard.press('ArrowRight'); // walk to step 2
+    let st = await revealState(page, ids);
+    assert.equal(st.step, '2');
+    // Leave to the tail slide, then come back.
+    await page.evaluate(() => document.querySelector('deck-stage').goTo(2));
+    await page.evaluate(() => document.querySelector('deck-stage').goTo(1));
+    st = await revealState(page, ids);
+    assert.equal(st.step, '0', 're-entry resets data-step to 0');
+    assert.deepEqual(st.revealed, { r1: false, r2: false, o1: false, u1: true }, 'base state on re-entry');
+    await page.close();
+  });
+
+  test('R resets data-step and re-hides later reveals', async () => {
+    const page = await browser.newPage();
+    await bootDeck(page, server.fixture('reveal-deck.html'));
+    const ids = ['r1', 'r2', 'o1', 'u1'];
+    await page.evaluate(() => document.querySelector('deck-stage').goTo(1));
+    await page.keyboard.press('ArrowRight'); // step 1: reveal-1 shown
+    let st = await revealState(page, ids);
+    assert.equal(st.revealed.r1, true, 'reveal-1 shown before R');
+    await page.keyboard.press('r');
+    assert.equal(await page.evaluate(() => document.querySelector('deck-stage').index), 0, 'R returns to slide 0');
+    st = await revealState(page, ids);
+    assert.equal(st.step, '0', 'R reset the reveal section to step 0');
+    assert.deepEqual(st.revealed, { r1: false, r2: false, o1: false, u1: true }, 're-hidden after R');
+    await page.close();
+  });
+
+  test('a section with no reveal attrs and no data-step-max stays non-stepped', async () => {
+    const page = await browser.newPage();
+    await bootDeck(page, server.fixture('reveal-deck.html'));
+    // The plain leading section (index 0) must not gain data-step-max.
+    const plainMax = await page.evaluate(() =>
+      document.querySelectorAll('section')[0].hasAttribute('data-step-max'));
+    assert.equal(plainMax, false, 'plain section must not be auto-stepped');
+    // ArrowRight on it advances the slide, not a step.
+    const idx = await page.evaluate(() => document.querySelector('deck-stage').index);
+    assert.equal(idx, 0);
+    await page.keyboard.press('ArrowRight');
+    assert.equal(await page.evaluate(() => document.querySelector('deck-stage').index), 1,
+      'ArrowRight advances the slide on a non-stepped section');
+    await page.close();
+  });
+
+  test('validation: multiple attrs honor the first; k=0 valid; invalid → always visible (with warnings)', async () => {
+    const page = await browser.newPage();
+    const warnings = [];
+    page.on('console', (msg) => { if (msg.type() === 'warning') warnings.push(msg.text()); });
+    await bootDeck(page, server.fixture('reveal-edge-deck.html'));
+    const ids = ['multi', 'zero', 'bad', 'neg'];
+
+    // Greatest valid k = 1 (#multi honors data-reveal="1"); invalid attrs ignored.
+    const max = await page.evaluate(() =>
+      document.querySelectorAll('section')[1].getAttribute('data-step-max'));
+    assert.equal(max, '1', 'invalid values do not contribute to the derived max');
+
+    // #rzero (data-reveal="0") and #empty (data-reveal="") are visible at every
+    // step; both must carry the data-revealed hook (step>=0 always true for
+    // rzero; empty is invalid → treated as always visible).
+    const alwaysAt = () => page.evaluate(() => ({
+      rzero: document.getElementById('rzero').hasAttribute('data-revealed'),
+      empty: document.getElementById('empty').hasAttribute('data-revealed'),
+    }));
+
+    await page.evaluate(() => document.querySelector('deck-stage').goTo(1));
+    // step 0: #multi (reveal>=1) hidden; #zero (only===0) shown; #bad/#neg always shown.
+    let st = await revealState(page, ids);
+    assert.deepEqual(st.revealed, { multi: false, zero: true, bad: true, neg: true }, 'edge step 0');
+    assert.deepEqual(await alwaysAt(), { rzero: true, empty: true }, 'k=0 and empty shown at step 0');
+    // step 1: #multi shown; #zero (only===0) hidden; #bad/#neg still always shown.
+    await page.keyboard.press('ArrowRight');
+    st = await revealState(page, ids);
+    assert.deepEqual(st.revealed, { multi: true, zero: false, bad: true, neg: true }, 'edge step 1');
+    assert.deepEqual(await alwaysAt(), { rzero: true, empty: true }, 'k=0 and empty shown at step 1');
+
+    // Warnings fired for the multiple-attr element and the two invalid values.
+    assert.ok(warnings.some((w) => /multiple reveal attributes/i.test(w)), 'warns on multiple reveal attrs');
+    assert.ok(warnings.some((w) => /data-reveal="abc"/.test(w)), 'warns on non-integer value');
+    assert.ok(warnings.some((w) => /data-reveal="-1"/.test(w)), 'warns on negative value');
+    // Each malformed attribute warns exactly once (the _revealWarned WeakSet),
+    // not on every nav — re-applying reveals across steps must not re-spam.
+    await page.keyboard.press('ArrowLeft');
+    await page.keyboard.press('ArrowRight');
+    assert.equal(
+      warnings.filter((w) => /data-reveal="abc"/.test(w)).length, 1,
+      'invalid value warns exactly once across navigation',
+    );
+    await page.close();
+  });
+});

--- a/tests/deck-kit/fixtures/reveal-deck.html
+++ b/tests/deck-kit/fixtures/reveal-deck.html
@@ -1,0 +1,29 @@
+<!doctype html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>reveal-deck fixture</title>
+<style>deck-stage:not(:defined){visibility:hidden}</style>
+</head>
+<body>
+<deck-stage width="1920" height="1080">
+  <section data-label="Plain"><h1>plain</h1></section>
+  <!-- No explicit data-step-max: deck-stage auto-derives it from the
+       reveal attributes below. Greatest k = 2 (data-reveal="2"), so the
+       section becomes data-step-max="2" (steps 0..2). -->
+  <section data-label="Reveals">
+    <h1>reveals</h1>
+    <div id="r1" data-reveal="1">reveal-1</div>
+    <div id="r2" data-reveal="2">reveal-2</div>
+    <div id="o1" data-reveal-only="1">only-1</div>
+    <div id="u1" data-reveal-until="1">until-1</div>
+    <!-- until="0": shown at step 0 only — used to observe an until element
+         re-appearing when the deck retreats back below k. -->
+    <div id="u0" data-reveal-until="0">until-0</div>
+  </section>
+  <section data-label="Tail"><h1>tail</h1></section>
+</deck-stage>
+<script src="/static/deck-kit/image-slot.js" defer></script>
+<script src="/static/deck-kit/deck-stage.js" defer></script>
+</body>
+</html>

--- a/tests/deck-kit/fixtures/reveal-edge-deck.html
+++ b/tests/deck-kit/fixtures/reveal-edge-deck.html
@@ -1,0 +1,35 @@
+<!doctype html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>reveal-edge-deck fixture</title>
+<style>deck-stage:not(:defined){visibility:hidden}</style>
+</head>
+<body>
+<deck-stage width="1920" height="1080">
+  <section data-label="Plain"><h1>plain</h1></section>
+  <!-- Validation edge cases. Greatest valid k = 1 (#multi honors
+       data-reveal="1"; #zero contributes k=0), so data-step-max="1".
+       Invalid values (#bad, #neg) are ignored and never contribute. -->
+  <section data-label="Edge">
+    <h1>edge</h1>
+    <!-- Multiple reveal attrs: honors the first in order (data-reveal). -->
+    <div id="multi" data-reveal="1" data-reveal-only="2">multi</div>
+    <!-- k=0 is valid: visible only in the base state. -->
+    <div id="zero" data-reveal-only="0">zero-only</div>
+    <!-- Non-integer → ignored → always visible. -->
+    <div id="bad" data-reveal="abc">bad</div>
+    <!-- Negative → ignored → always visible. -->
+    <div id="neg" data-reveal="-1">neg</div>
+    <!-- k=0 on data-reveal: step >= 0 is always true → always shown, but the
+         data-revealed hook IS set (distinct from the invalid "always" cases). -->
+    <div id="rzero" data-reveal="0">reveal-zero</div>
+    <!-- Empty value → invalid → ignored → always visible. -->
+    <div id="empty" data-reveal="">empty</div>
+  </section>
+  <section data-label="Tail"><h1>tail</h1></section>
+</deck-stage>
+<script src="/static/deck-kit/image-slot.js" defer></script>
+<script src="/static/deck-kit/deck-stage.js" defer></script>
+</body>
+</html>

--- a/tests/deck-kit/fixtures/reveal-explicit-deck.html
+++ b/tests/deck-kit/fixtures/reveal-explicit-deck.html
@@ -1,0 +1,24 @@
+<!doctype html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>reveal-explicit-deck fixture</title>
+<style>deck-stage:not(:defined){visibility:hidden}</style>
+</head>
+<body>
+<deck-stage width="1920" height="1080">
+  <section data-label="Plain"><h1>plain</h1></section>
+  <!-- Explicit data-step-max="5" AND reveal attributes whose greatest k is
+       2. Auto-derivation must NOT clobber the author's explicit value: the
+       section must stay data-step-max="5". -->
+  <section data-label="ExplicitReveals" data-step-max="5">
+    <h1>explicit</h1>
+    <div id="r1" data-reveal="1">reveal-1</div>
+    <div id="r2" data-reveal="2">reveal-2</div>
+  </section>
+  <section data-label="Tail"><h1>tail</h1></section>
+</deck-stage>
+<script src="/static/deck-kit/image-slot.js" defer></script>
+<script src="/static/deck-kit/deck-stage.js" defer></script>
+</body>
+</html>


### PR DESCRIPTION
## What

Adds declarative step reveals to deck-kit's `<deck-stage>`: three opt-in attributes on any `<section>` descendant that drive progressive reveals without hand-written per-step CSS or hand-counted step indices.

| Attribute | Element shown when |
|---|---|
| `data-reveal="k"` | `data-step >= k` |
| `data-reveal-only="k"` | `data-step === k` |
| `data-reveal-until="k"` | `data-step <= k` |

## How

- `deck-stage` auto-derives the section's `data-step-max` as the greatest `k` across the three attributes, so the author never counts steps. An explicit author-set `data-step-max` always wins and is never overwritten (tracked in a `WeakSet`).
- A `data-revealed` hook is toggled on each reveal element from the current `data-step`. One global stylesheet is injected so un-styled reveal elements hide by default (`opacity: 0; pointer-events: none`); decks animate the transition by styling `[data-revealed]`.
- `k=0` is valid. A non-integer/negative value is ignored (element stays visible) with a `console.warn`; multiple reveal attributes on one element honor the first in precedence order, also with a warn (once per element).

## Contract / docs

- Append-only: `data-reveal`, `data-reveal-only`, `data-reveal-until` added to the `SECTION_DATA_ATTRS` allowlist; `data-revealed` documented as a CSS hook. No existing name renamed or removed, so no new filename (deck-kit rule 5).
- `static/deck-kit/README.md` documents the three attributes and the hook.

## Tests / verification

- `npm run test:deck-kit`: 80/80 pass. New behavioral tests cover auto-derivation, the semantics table at every step, enter/leave reset, `R` reset, `data-reveal-until` re-appearance on retreat, validation (`k=0`, empty, invalid, multiple attributes, warn-once), and the injected default-hide stylesheet. The contract suite locks all three names behaviorally.
- No visual change to the existing explicit-step decks: `snapshot:baseline` (before) vs `snapshot:diff` (after) is identical for Romania (54/54) and Valencia, except a blinking terminal cursor caught mid-phase.

Fixes #56