### PR TITLE
🐛 fix(deck-kit): rebase CSS-relative url() in rail thumbnails

### DIFF
--- a/static/deck-kit/deck-stage.js
+++ b/static/deck-kit/deck-stage.js
@@ -773,9 +773,17 @@
       // each thumb host (see _syncThumbHostAttrs) so the same selectors
       // match inside the thumbnail's shadow tree.
       const authorCss = Array.from(document.styleSheets).map((sh) => {
+        let css;
         try {
-          return Array.from(sh.cssRules).map((r) => r.cssText).join('\n');
+          css = Array.from(sh.cssRules).map((r) => r.cssText).join('\n');
         } catch (e) { return ''; }
+        // The constructed sheet every thumbnail adopts resolves relative
+        // url() against the DOCUMENT, not the originating .css — so rebase
+        // each sheet's relative url() to absolute against its own href
+        // (inline <style> has href === null → document base, already
+        // correct) before concatenating, or external-stylesheet
+        // backgrounds 404 inside the thumbnails. (#62)
+        return this._rewriteCssUrls(css, sh.href || document.baseURI);
       }).join('\n')
         // The shadow host is featureless outside the functional :host(...)
         // form, so any compound on :root — [attr], .class, #id, :pseudo —
@@ -816,6 +824,38 @@
         this._adoptedSheet = null;
         this._authorCss = authorCss;
       }
+    }
+
+    /** Rebase relative url(...) refs in a stylesheet's serialized text to
+     *  absolute against `base` (the sheet's own href, or the document for
+     *  inline <style>). The rail adopts all author CSS via a single
+     *  CONSTRUCTED CSSStyleSheet whose base URL is the document, not each
+     *  originating .css — so a relative url('../assets/x.webp') in an external
+     *  sheet would otherwise re-resolve against the document directory and 404
+     *  inside the thumbnails. Same-document fragment refs (url(#filter) for
+     *  SVG) and data: URIs are left untouched; already-absolute refs pass
+     *  through new URL() unchanged. (#62) */
+    _rewriteCssUrls(cssText, base) {
+      if (!cssText || !base) return cssText || '';
+      // Match url( "..." | '...' | unquoted ). The quoted branches are
+      // escape-aware ((?:[^"\\]|\\.)*) so a data: URI whose serialized form
+      // carries backslash-escaped inner quotes — Chromium emits inline-SVG
+      // backgrounds as url("data:…\"…\"…") — is captured whole and skipped
+      // below, not mangled. The unquoted branch excludes whitespace
+      // ([^)\s]*) — CSSOM never emits an unquoted url() with interior
+      // whitespace — which also keeps matching linear (a lazy [^)]*? would
+      // backtrack ~cubically on a url( with a long whitespace run and no
+      // closing paren).
+      return cssText.replace(
+        /url\(\s*(?:"((?:[^"\\]|\\.)*)"|'((?:[^'\\]|\\.)*)'|([^)\s]*))\s*\)/gi,
+        (match, dq, sq, uq) => {
+          const raw = (dq != null ? dq : sq != null ? sq : uq || '').trim();
+          if (!raw || raw.startsWith('#') || /^data:/i.test(raw)) return match;
+          try {
+            return 'url("' + new URL(raw, base).href + '")';
+          } catch (e) { return match; }
+        },
+      );
     }
 
     _syncThumbHostAttrs(host, cs) {

--- a/static/deck-kit/deck-stage.js
+++ b/static/deck-kit/deck-stage.js
@@ -833,8 +833,13 @@
      *  originating .css — so a relative url('../assets/x.webp') in an external
      *  sheet would otherwise re-resolve against the document directory and 404
      *  inside the thumbnails. Same-document fragment refs (url(#filter) for
-     *  SVG) and data: URIs are left untouched; already-absolute refs pass
-     *  through new URL() unchanged. (#62) */
+     *  SVG) are left untouched while external-with-fragment refs
+     *  (url(sprite.svg#icon)) are rebased and keep their fragment; data: URIs
+     *  pass through and already-absolute refs go through new URL() unchanged.
+     *  Assumes `url(` only ever appears as the CSS url() functional notation,
+     *  never as literal text inside a string value (e.g. content: "see url(x)") —
+     *  telling the two apart needs a full value tokenizer, and no deck CSS puts
+     *  url( inside a string. (#62) */
     _rewriteCssUrls(cssText, base) {
       if (!cssText || !base) return cssText || '';
       // Match url( "..." | '...' | unquoted ). The quoted branches are

--- a/static/presentations/mock-mvc-in-action/README.md
+++ b/static/presentations/mock-mvc-in-action/README.md
@@ -96,12 +96,14 @@ is faithful slide-for-slide; the mechanics changed as follows:
   (`?family=Oswald|Montserrat|Roboto`). The cover `<h1>`/`<h2>` request bold but get
   a synthesized (faux) bold of the 400 Roboto/Oswald face — reproducing the original
   title's lighter look rather than a heavier true-700 face.
-- **CSS background `url()`s are root-absolute** (`/presentations/mock-mvc-in-action/assets/…`).
-  deck-stage's rail thumbnails adopt a *constructed* stylesheet whose base URL is the
-  document, not `styles/deck.css`, so a `../assets/…` relative URL would 404 in the
-  thumbnails (this deck is the first with CSS-relative backgrounds). The deck always
-  deploys at this path. A deck-kit-side fix (rewriting relative `url()`s during the
-  rail CSS snapshot) is tracked as a follow-up so future decks can use relative URLs.
+- **CSS background `url()`s are relative** (`../assets/…`, resolved against
+  `styles/deck.css`). This deck is the first with CSS-relative backgrounds. deck-stage's
+  rail thumbnails adopt a *constructed* stylesheet whose base URL is the document, not
+  `styles/deck.css` — a relative URL used to 404 in the thumbnails, so this deck shipped
+  with a per-deck root-absolute workaround (`/presentations/mock-mvc-in-action/assets/…`).
+  That workaround is gone: deck-stage now rebases relative `url()`s against each source
+  sheet's own `href` during the rail CSS snapshot (issue #62), so ordinary relative
+  backgrounds resolve in both the live slides and the thumbnails.
 
 All the original animations are reproduced. The two infinite decorative loops — the
 Project Reactor logo pulse (slide 8) and the mockingbird silhouette colorize (slide

--- a/static/presentations/mock-mvc-in-action/styles/deck.css
+++ b/static/presentations/mock-mvc-in-action/styles/deck.css
@@ -111,8 +111,7 @@ deck-stage section { font-family: var(--font-body); color: var(--fg); }
 .slide3 .beer-wrapper {
   height: 100%;
   display: flex; flex-direction: column;
-  /* Root-absolute — see the note on .slide7 (rail-thumbnail stylesheet base). */
-  background: url('/presentations/mock-mvc-in-action/assets/beer-bg.webp') no-repeat 50% 50%;
+  background: url('../assets/beer-bg.webp') no-repeat 50% 50%;
 }
 .slide3 .beer-bottle {
   flex: 1; min-height: 1px;
@@ -142,10 +141,7 @@ deck-stage section { font-family: var(--font-body); color: var(--fg); }
 .slide7 {
   padding: 0;
   display: flex; flex-direction: column;
-  /* Root-absolute so it resolves both as the light-DOM slide background AND inside
-   * deck-stage's constructed rail-thumbnail stylesheet (whose base URL is the
-   * document, not styles/deck.css). The deck always deploys at this path. */
-  background: url('/presentations/mock-mvc-in-action/assets/reactor.webp') no-repeat 50% 50%;
+  background: url('../assets/reactor.webp') no-repeat 50% 50%;
   background-size: cover;
 }
 .slide7 .title {
@@ -180,8 +176,7 @@ deck-stage section { font-family: var(--font-body); color: var(--fg); }
 .slide-summary .content { flex: 1; display: flex; }
 .slide-summary .col { flex: 1; }
 .slide-summary .col.image {
-  /* Root-absolute — see the note on .slide7 (rail-thumbnail stylesheet base). */
-  background: url('/presentations/mock-mvc-in-action/assets/mockingbird-silhouette.webp') no-repeat 50% 50%;
+  background: url('../assets/mockingbird-silhouette.webp') no-repeat 50% 50%;
   background-size: contain;
   animation: colorize 4s linear infinite;
 }

--- a/tests/deck-kit/deck-stage-css-url.spec.js
+++ b/tests/deck-kit/deck-stage-css-url.spec.js
@@ -89,6 +89,8 @@ describe('deck-stage author-CSS url() rebasing', () => {
         // document.baseURI as the base; relative refs rebase against it.
         inlineDoc: rw('.k{background-image:url(scene.png)}', docBase),
         frag: rw('.d{clip-path:url("#clip")}'),
+        // External resource with a fragment — rebased, fragment preserved.
+        fileFrag: rw('.o{mask:url("sprite.svg#icon")}'),
         data: rw('.e{background-image:url("data:image/png;base64,AAAA")}'),
         // Chromium serializes inline-SVG data: URIs with backslash-escaped "
         dataEsc: rw('.m{background-image:url("data:image/svg+xml;utf8,<svg fill=\\"red\\"></svg>")}'),
@@ -114,6 +116,10 @@ describe('deck-stage author-CSS url() rebasing', () => {
     assert.match(out.inlineDoc, /url\("https:\/\/example\.com\/deck\/scene\.png"\)/);
     // Same-document fragment refs (SVG filter/mask) must stay relative.
     assert.match(out.frag, /url\("#clip"\)/);
+    // External-resource fragment is rebased to absolute AND keeps its fragment
+    // (distinct from the pure-#frag skip above — a future "skip any #" refactor
+    // would regress this).
+    assert.match(out.fileFrag, /url\("https:\/\/example\.com\/deck\/styles\/sprite\.svg#icon"\)/);
     // data: URIs are already absolute — untouched.
     assert.match(out.data, /url\("data:image\/png;base64,AAAA"\)/);
     // Escaped-quote data: URI preserved verbatim, NOT rebased (#62 regression).

--- a/tests/deck-kit/deck-stage-css-url.spec.js
+++ b/tests/deck-kit/deck-stage-css-url.spec.js
@@ -1,0 +1,130 @@
+'use strict';
+
+// Issue #62 — rail thumbnails adopt a CONSTRUCTED CSSStyleSheet whose base URL
+// is the document, not each originating .css file. A relative url('../assets/…')
+// in an external deck stylesheet therefore re-resolves against the document
+// directory and 404s inside the thumbnails. _snapshotAuthorCss must rewrite
+// relative url() to absolute against each source sheet's own href — while
+// leaving fragment refs and (escaped-quote) data: URIs untouched.
+
+const { test, describe, before, after } = require('node:test');
+const assert = require('node:assert/strict');
+const { chromium } = require('playwright');
+const { startServer, bootDeck } = require('./_helpers');
+
+describe('deck-stage author-CSS url() rebasing', () => {
+  let server;
+  let browser;
+
+  before(async () => {
+    server = await startServer();
+    browser = await chromium.launch();
+  });
+
+  after(async () => {
+    if (browser) await browser.close();
+    if (server) await server.close();
+  });
+
+  test('CSS-relative url() background resolves in the thumbnail (no 404)', async () => {
+    const page = await browser.newPage();
+    const failed = [];
+    page.on('response', (r) => { if (r.status() >= 400) failed.push(r.url()); });
+    await bootDeck(page, server.fixture('css-url-bg/index.html'));
+
+    // Force every thumb to materialize deterministically rather than depending
+    // on the IntersectionObserver firing in headless.
+    const { relBg, dataBg } = await page.evaluate(() => {
+      const stage = document.querySelector('deck-stage');
+      (stage._thumbs || []).forEach((t) => stage._materialize(t));
+      return {
+        relBg: getComputedStyle(stage._thumbs[0].clone).backgroundImage,
+        dataBg: getComputedStyle(stage._thumbs[1].clone).backgroundImage,
+      };
+    });
+    // Let the thumbnail's background fetch settle so a wrong-path 404 is seen.
+    await page.waitForLoadState('networkidle');
+
+    assert.match(
+      relBg, /\/css-url-bg\/assets\/bg\.svg/,
+      'thumb background must resolve against the stylesheet href',
+    );
+    assert.doesNotMatch(
+      relBg, /\/fixtures\/assets\/bg\.svg/,
+      'thumb background must NOT re-resolve against the document directory',
+    );
+    // Finding 1 regression: a data: URI whose serialized cssText carries
+    // backslash-escaped inner quotes (Chromium's inline-SVG form) must pass
+    // through untouched, not get rebased against the stylesheet dir.
+    assert.match(
+      dataBg, /^url\("data:image\/svg\+xml/,
+      'data: URI background must be preserved, not rebased',
+    );
+    assert.doesNotMatch(
+      dataBg, /css-url-bg\/styles/,
+      'data: URI background must NOT be rebased against the stylesheet dir',
+    );
+    assert.equal(
+      failed.filter((u) => /bg\.svg/.test(u)).length, 0,
+      `no 404 for the background asset; failed responses: ${failed.join(', ') || '(none)'}`,
+    );
+    await page.close();
+  });
+
+  test('_rewriteCssUrls rebases relative refs and preserves fragment/data/absolute', async () => {
+    const page = await browser.newPage();
+    await bootDeck(page, server.fixture('minimal-deck.html'));
+    const out = await page.evaluate(() => {
+      const stage = document.querySelector('deck-stage');
+      const base = 'https://example.com/deck/styles/deck.css';
+      const docBase = 'https://example.com/deck/index.html';
+      const rw = (css, b) => stage._rewriteCssUrls(css, b || base);
+      return {
+        dq: rw('.a{background-image:url("../img/x.png")}'),
+        sq: rw(".b{background-image:url('../img/y.png')}"),
+        uq: rw('.c{background-image:url(../img/z.png)}'),
+        sameDir: rw('.h{background-image:url(sib.png)}'),
+        multi: rw('.i{background-image:url(a.png),url(b.png)}'),
+        // Inline <style> has href === null → _snapshotAuthorCss passes
+        // document.baseURI as the base; relative refs rebase against it.
+        inlineDoc: rw('.k{background-image:url(scene.png)}', docBase),
+        frag: rw('.d{clip-path:url("#clip")}'),
+        data: rw('.e{background-image:url("data:image/png;base64,AAAA")}'),
+        // Chromium serializes inline-SVG data: URIs with backslash-escaped "
+        dataEsc: rw('.m{background-image:url("data:image/svg+xml;utf8,<svg fill=\\"red\\"></svg>")}'),
+        abs: rw('.f{background-image:url("https://cdn.example.com/a.png")}'),
+        rootAbs: rw('.g{background-image:url("/root.png")}'),
+        emptyCss: rw(''),
+        emptyUrl: rw('.n{background-image:url("")}'),
+      };
+    });
+    await page.close();
+
+    assert.match(out.dq, /url\("https:\/\/example\.com\/deck\/img\/x\.png"\)/);
+    assert.match(out.sq, /url\("https:\/\/example\.com\/deck\/img\/y\.png"\)/);
+    assert.match(out.uq, /url\("https:\/\/example\.com\/deck\/img\/z\.png"\)/);
+    // Same-directory (no ../) relative ref rebases against the stylesheet dir.
+    assert.match(out.sameDir, /url\("https:\/\/example\.com\/deck\/styles\/sib\.png"\)/);
+    // Both url() in one declaration rebase (the /g flag walks every token).
+    assert.match(
+      out.multi,
+      /url\("https:\/\/example\.com\/deck\/styles\/a\.png"\),url\("https:\/\/example\.com\/deck\/styles\/b\.png"\)/,
+    );
+    // Inline <style> (document base) rebases to the document directory.
+    assert.match(out.inlineDoc, /url\("https:\/\/example\.com\/deck\/scene\.png"\)/);
+    // Same-document fragment refs (SVG filter/mask) must stay relative.
+    assert.match(out.frag, /url\("#clip"\)/);
+    // data: URIs are already absolute — untouched.
+    assert.match(out.data, /url\("data:image\/png;base64,AAAA"\)/);
+    // Escaped-quote data: URI preserved verbatim, NOT rebased (#62 regression).
+    assert.match(out.dataEsc, /url\("data:image\/svg\+xml/);
+    assert.doesNotMatch(out.dataEsc, /example\.com/);
+    // Absolute http(s) refs pass through unchanged.
+    assert.match(out.abs, /url\("https:\/\/cdn\.example\.com\/a\.png"\)/);
+    // Root-absolute rebases to the origin root (resolves identically).
+    assert.match(out.rootAbs, /url\("https:\/\/example\.com\/root\.png"\)/);
+    // Guards: empty input and empty url() are no-ops.
+    assert.equal(out.emptyCss, '');
+    assert.match(out.emptyUrl, /url\(""\)/);
+  });
+});

--- a/tests/deck-kit/fixtures/css-url-bg/assets/bg.svg
+++ b/tests/deck-kit/fixtures/css-url-bg/assets/bg.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="160" height="90"><rect width="160" height="90" fill="#3366cc"/></svg>

--- a/tests/deck-kit/fixtures/css-url-bg/index.html
+++ b/tests/deck-kit/fixtures/css-url-bg/index.html
@@ -1,0 +1,18 @@
+<!doctype html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>css-url-bg fixture</title>
+<link rel="stylesheet" href="styles/deck.css">
+<style>deck-stage:not(:defined){visibility:hidden}</style>
+</head>
+<body>
+<deck-stage width="1920" height="1080">
+  <section class="bg-slide" data-label="Backdrop"><h1>1</h1></section>
+  <section class="data-slide" data-label="DataURI"><h1>2</h1></section>
+  <section data-label="Three"><h1>3</h1></section>
+</deck-stage>
+<script src="/static/deck-kit/image-slot.js" defer></script>
+<script src="/static/deck-kit/deck-stage.js" defer></script>
+</body>
+</html>

--- a/tests/deck-kit/fixtures/css-url-bg/styles/deck.css
+++ b/tests/deck-kit/fixtures/css-url-bg/styles/deck.css
@@ -1,0 +1,18 @@
+/* External stylesheet living one directory below index.html, so a relative
+   url('../assets/...') resolves against THIS file's directory — different from
+   the document's directory. Exercises issue #62: the rail thumbnails adopt a
+   constructed sheet based on the document, not this .css, so an un-rewritten
+   relative url() re-resolves against the document dir and 404s. */
+.bg-slide {
+  background-image: url('../assets/bg.svg');
+  background-size: cover;
+  background-repeat: no-repeat;
+}
+
+/* A self-contained inline-SVG data: URI with literal double-quotes (authored
+   single-quoted). Chromium serializes this rule's cssText as double-quoted
+   with backslash-escaped inner quotes — it must be passed through UNCHANGED,
+   not rebased against the stylesheet dir (issue #62 escaped-quote regression). */
+.data-slide {
+  background-image: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 80 80"><rect x="16" y="16" width="48" height="48" fill="none" stroke="%23C5C8DC"/></svg>');
+}


### PR DESCRIPTION
## What

Rail thumbnails build by snapshotting the document's author CSS into a constructed `CSSStyleSheet` that each thumbnail's shadow root adopts. A constructed sheet's base URL is the **document**, not the originating `.css` — so relative `url()` backgrounds in an external deck stylesheet re-resolved against the document directory and 404'd inside the thumbnails (the live slides were unaffected).

`_snapshotAuthorCss` now rebases each source sheet's relative `url()` to absolute against its own `href` (via a new `_rewriteCssUrls` helper) before concatenating, so decks can use ordinary relative `url('../assets/…')` again. Internal rail-rendering detail — no change to the public `<deck-stage>` contract.

## Changes

- **`static/deck-kit/deck-stage.js`** — `_rewriteCssUrls(css, base)` + per-sheet rebasing in `_snapshotAuthorCss`. Quoted-url branches are escape-aware so Chromium's backslash-escaped inline-SVG `data:` URIs are skipped (not mangled); `url(#fragment)` and `data:` refs are left untouched; the unquoted branch uses `[^)\s]*` to keep matching linear.
- **`static/presentations/mock-mvc-in-action/`** — reverted the per-deck root-absolute workaround back to relative `url('../assets/…')`; README note updated.
- **`tests/deck-kit/deck-stage-css-url.spec.js` + `fixtures/css-url-bg/`** — assert a CSS-relative `url()` background resolves in the thumbnail with no 404, a `data:` URI is preserved, and unit-test the rewrite helper (fragment / data / absolute / root-absolute / inline-style / multi-url / empty).

## Verification

- `npm run test:deck-kit` — **91/91 pass**.
- mock-mvc-in-action: thumbnail background resolves correctly, **0 wrong-path 404s**.
- 2026-devtalks-romania: `data:` SVG background preserved verbatim in the snapshot (regression guard for the escaped-quote case).

Fixes #62